### PR TITLE
Add AT Protocol OAuth authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ Serves activity data on `http://127.0.0.1:8000`.
 uv run subscribe
 ```
 
+### Backfill
+
+The subscriber only indexes records as they are created or updated in real time. If a user already has `app.thedistance.activity` records on their PDS from before the subscriber was running, those records will not be in the database. The backfill command fetches all existing records from a user's PDS and indexes them:
+
+```
+cd appview
+uv run backfill <handle>
+```
+
+There is also an API endpoint `POST /api/backfill` that does the same thing, restricted to the authenticated user's own account.
+
 ## Frontend
 
 ```

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You will need a local Postgres database created and running. Set the connection 
 
 ## AppView
 
-The appview is made up of two processes that run simultaneously: a **subscriber** and an **API server**. The subscriber connects to Jetstream and listens for `app.thedistance.activity` records on the network. When it sees one created, updated, or deleted, it writes the change to Postgres. The API server reads from that same database and serves the indexed data over HTTP. Both processes need to be running at the same time, each in its own terminal.
+The appview is made up of two processes that run simultaneously: a **subscriber** and an **API server**. The subscriber connects to Jetstream and listens for records on the network. When it sees one created, updated, or deleted, it writes the change to Postgres. The API server reads from that same database and serves the indexed data over HTTP. Both processes need to be running at the same time.
 
 ### Setup
 
@@ -41,13 +41,25 @@ Copy the example env file and fill in your Postgres connection string:
 cp .env.example .env
 ```
 
+Generate a session secret key and add it to `.env` as `SESSION_SECRET_KEY`:
+
+```
+python -c "import secrets; print(secrets.token_hex(32))"
+```
+
+Generate the OAuth client signing key and add it to `.env` as `CLIENT_SECRET_JWK`:
+
+```
+uv run generate-jwk
+```
+
 ### Run the API server
 
 ```
 uv run start
 ```
 
-Serves activity data on `http://localhost:8000`.
+Serves activity data on `http://127.0.0.1:8000`.
 
 ### Run the subscriber
 
@@ -59,8 +71,10 @@ uv run subscribe
 
 ```
 cd web
-python -m http.server 8001
+pnpm i && pnpm start
 ```
+
+Access at `http://127.0.0.1:8001`. **Note**: You cannot use `localhost`.
 
 ## Scripts
 

--- a/appview/.env.example
+++ b/appview/.env.example
@@ -1,1 +1,9 @@
 DATABASE_URL="postgresql://user:pass@localhost:5432/thedistance"
+# NOTE: These must be 127.0.0.1 and not localhost due to the at proto auth spec
+APP_URL="http://127.0.0.1:8000"
+# Change the port here if you use something other than 8001
+FRONTEND_URL="http://127.0.0.1:8001"
+# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+SESSION_SECRET_KEY="generate-a-random-hex-string"
+# Generate with: cd appview && uv run generate-jwk
+CLIENT_SECRET_JWK='{"kty":"EC","crv":"P-256",...}'

--- a/appview/app/auth.py
+++ b/appview/app/auth.py
@@ -1,19 +1,26 @@
-from fastapi import Header, HTTPException
+from fastapi import HTTPException, Request
+
+from app.db import get_connection, get_oauth_session
 
 
-def require_auth(
-    authorization: str | None = Header(default=None),
-    x_debug_did: str | None = Header(default=None),
-) -> str:
-    """Verify the request is authenticated and return the user's DID.
+def require_auth(request: Request) -> dict:
+    """Verify the request has a valid OAuth session and return the session dict.
 
-    Placeholder until real AT Protocol OAuth is in place. For now, requires
-    an Authorization header (value is not validated) and reads the DID from
-    X-Debug-DID. Once OAuth is implemented, the DID will come from the
-    access token's sub claim.
+    Reads user_did from the session cookie, then looks up the full OAuth
+    session from the database. Returns the session row as a dict.
     """
-    if not authorization:
-        raise HTTPException(status_code=401, detail="Authorization required")
-    if not x_debug_did:
-        raise HTTPException(status_code=401, detail="Missing X-Debug-DID header")
-    return x_debug_did
+    user_did = request.session.get("user_did")
+    if not user_did:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    conn = get_connection()
+    try:
+        session = get_oauth_session(conn, user_did)
+    finally:
+        conn.close()
+
+    if not session:
+        request.session.clear()
+        raise HTTPException(status_code=401, detail="Session expired")
+
+    return session

--- a/appview/app/backfill.py
+++ b/appview/app/backfill.py
@@ -3,28 +3,11 @@ import logging
 import httpx
 
 from app.db import get_connection, upsert_activity
+from app.identity import resolve_identity
 
 log = logging.getLogger(__name__)
 
-RESOLVE_HANDLE_URL = "https://bsky.social/xrpc/com.atproto.identity.resolveHandle"
-PLC_DIRECTORY_URL = "https://plc.directory"
 COLLECTION = "app.thedistance.activity"
-
-
-def resolve_handle(client, handle):
-    resp = client.get(RESOLVE_HANDLE_URL, params={"handle": handle})
-    resp.raise_for_status()
-    return resp.json()["did"]
-
-
-def resolve_pds(client, did):
-    resp = client.get(f"{PLC_DIRECTORY_URL}/{did}")
-    resp.raise_for_status()
-    doc = resp.json()
-    for service in doc.get("service", []):
-        if service.get("id") == "#atproto_pds":
-            return service["serviceEndpoint"]
-    raise ValueError(f"No PDS found in DID document for {did}")
 
 
 def list_records(client, pds, did):
@@ -54,11 +37,8 @@ def backfill(handle):
     log.info("Starting backfill for %s", handle)
 
     with httpx.Client() as client:
-        did = resolve_handle(client, handle)
-        log.info("Resolved %s to %s", handle, did)
-
-        pds = resolve_pds(client, did)
-        log.info("PDS for %s: %s", did, pds)
+        did, resolved_handle, pds = resolve_identity(client, handle)
+        log.info("Resolved %s to %s (PDS: %s)", resolved_handle, did, pds)
 
         conn = get_connection()
         count = 0

--- a/appview/app/cli.py
+++ b/appview/app/cli.py
@@ -29,3 +29,10 @@ def backfill():
     handle = sys.argv[1]
     result = _backfill(handle)
     print(f"Backfilled {result['records']} records for {result['did']}")
+
+
+def generate_jwk():
+    from authlib.jose import JsonWebKey
+
+    key = JsonWebKey.generate_key("EC", "P-256", is_private=True)
+    print(key.as_json(is_private=True))

--- a/appview/app/config.py
+++ b/appview/app/config.py
@@ -11,6 +11,12 @@ class Settings(BaseSettings):
     )
 
     database_url: str
+    # Must be 127.0.0.1, not localhost. AT Protocol OAuth (RFC 8252) requires
+    # loopback IP for redirect URIs, and cookies must be on the same site.
+    app_url: str = "http://127.0.0.1:8000"
+    frontend_url: str = "http://127.0.0.1:8001"
+    session_secret_key: str = "change-me-in-production"
+    client_secret_jwk: str = ""
 
 
 @lru_cache

--- a/appview/app/db.py
+++ b/appview/app/db.py
@@ -10,7 +10,8 @@ def get_connection():
 
 def init_db():
     with get_connection() as conn:
-        conn.execute("""
+        conn.execute(
+            """
             CREATE TABLE IF NOT EXISTS activities (
                 did TEXT NOT NULL,
                 rkey TEXT NOT NULL,
@@ -38,25 +39,65 @@ def init_db():
                 indexed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                 PRIMARY KEY (did, rkey)
             )
-        """)
-        conn.execute("""
+        """
+        )
+        conn.execute(
+            """
             CREATE INDEX IF NOT EXISTS idx_activities_started_at
                 ON activities (started_at DESC)
-        """)
-        conn.execute("""
+        """
+        )
+        conn.execute(
+            """
             CREATE INDEX IF NOT EXISTS idx_activities_did
                 ON activities (did)
-        """)
-        conn.execute("""
+        """
+        )
+        conn.execute(
+            """
             CREATE TABLE IF NOT EXISTS cursor (
                 id INTEGER PRIMARY KEY CHECK (id = 1),
                 cursor_value BIGINT NOT NULL
             )
-        """)
+        """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS oauth_auth_requests (
+                state TEXT PRIMARY KEY,
+                authserver_iss TEXT NOT NULL,
+                did TEXT,
+                handle TEXT,
+                pds_url TEXT,
+                pkce_verifier TEXT NOT NULL,
+                scope TEXT NOT NULL,
+                dpop_authserver_nonce TEXT NOT NULL,
+                dpop_private_jwk TEXT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+        """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS oauth_sessions (
+                did TEXT PRIMARY KEY,
+                handle TEXT NOT NULL,
+                pds_url TEXT NOT NULL,
+                authserver_iss TEXT NOT NULL,
+                access_token TEXT NOT NULL,
+                refresh_token TEXT NOT NULL,
+                dpop_authserver_nonce TEXT NOT NULL,
+                dpop_pds_nonce TEXT,
+                dpop_private_jwk TEXT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+        """
+        )
 
 
 def upsert_activity(conn, did, rkey, record):
-    conn.execute("""
+    conn.execute(
+        """
         INSERT INTO activities (
             did, rkey, sport_type, title, description, started_at,
             elapsed_time, moving_time, distance, elevation_gain,
@@ -91,31 +132,33 @@ def upsert_activity(conn, did, rkey, record):
             source = EXCLUDED.source,
             created_at = EXCLUDED.created_at,
             indexed_at = NOW()
-    """, (
-        did,
-        rkey,
-        record["sportType"],
-        record.get("title"),
-        record.get("description"),
-        record["startedAt"],
-        record["elapsedTime"],
-        record["movingTime"],
-        record["distance"],
-        record.get("elevationGain"),
-        record.get("avgSpeed"),
-        record.get("maxSpeed"),
-        record.get("avgHeartRate"),
-        record.get("maxHeartRate"),
-        record.get("avgCadence"),
-        record.get("maxCadence"),
-        record.get("avgPower"),
-        record.get("maxPower"),
-        record.get("calories"),
-        record.get("polyline"),
-        record.get("device"),
-        record.get("source"),
-        record["createdAt"],
-    ))
+    """,
+        (
+            did,
+            rkey,
+            record["sportType"],
+            record.get("title"),
+            record.get("description"),
+            record["startedAt"],
+            record["elapsedTime"],
+            record["movingTime"],
+            record["distance"],
+            record.get("elevationGain"),
+            record.get("avgSpeed"),
+            record.get("maxSpeed"),
+            record.get("avgHeartRate"),
+            record.get("maxHeartRate"),
+            record.get("avgCadence"),
+            record.get("maxCadence"),
+            record.get("avgPower"),
+            record.get("maxPower"),
+            record.get("calories"),
+            record.get("polyline"),
+            record.get("device"),
+            record.get("source"),
+            record["createdAt"],
+        ),
+    )
     conn.commit()
 
 
@@ -130,10 +173,13 @@ def get_cursor(conn):
 
 
 def set_cursor(conn, cursor_value):
-    conn.execute("""
+    conn.execute(
+        """
         INSERT INTO cursor (id, cursor_value) VALUES (1, %s)
         ON CONFLICT (id) DO UPDATE SET cursor_value = EXCLUDED.cursor_value
-    """, (cursor_value,))
+    """,
+        (cursor_value,),
+    )
     conn.commit()
 
 
@@ -156,6 +202,131 @@ def list_activities(conn, limit=50, offset=0, sport_type=None, did=None):
     params.extend([limit, offset])
 
     return conn.execute(query, params).fetchall()
+
+
+# OAuth auth request helpers
+
+
+def save_auth_request(
+    conn,
+    state,
+    authserver_iss,
+    did,
+    handle,
+    pds_url,
+    pkce_verifier,
+    scope,
+    dpop_authserver_nonce,
+    dpop_private_jwk,
+):
+    conn.execute(
+        """
+        INSERT INTO oauth_auth_requests (
+            state, authserver_iss, did, handle, pds_url,
+            pkce_verifier, scope, dpop_authserver_nonce, dpop_private_jwk
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+    """,
+        (
+            state,
+            authserver_iss,
+            did,
+            handle,
+            pds_url,
+            pkce_verifier,
+            scope,
+            dpop_authserver_nonce,
+            dpop_private_jwk,
+        ),
+    )
+    conn.commit()
+
+
+def get_auth_request(conn, state):
+    return conn.execute(
+        "SELECT * FROM oauth_auth_requests WHERE state = %s", (state,)
+    ).fetchone()
+
+
+def delete_auth_request(conn, state):
+    conn.execute("DELETE FROM oauth_auth_requests WHERE state = %s", (state,))
+    conn.commit()
+
+
+# OAuth session helpers
+
+
+def save_oauth_session(
+    conn,
+    did,
+    handle,
+    pds_url,
+    authserver_iss,
+    access_token,
+    refresh_token,
+    dpop_authserver_nonce,
+    dpop_private_jwk,
+):
+    conn.execute(
+        """
+        INSERT INTO oauth_sessions (
+            did, handle, pds_url, authserver_iss,
+            access_token, refresh_token,
+            dpop_authserver_nonce, dpop_private_jwk
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (did) DO UPDATE SET
+            handle = EXCLUDED.handle,
+            pds_url = EXCLUDED.pds_url,
+            authserver_iss = EXCLUDED.authserver_iss,
+            access_token = EXCLUDED.access_token,
+            refresh_token = EXCLUDED.refresh_token,
+            dpop_authserver_nonce = EXCLUDED.dpop_authserver_nonce,
+            dpop_private_jwk = EXCLUDED.dpop_private_jwk
+    """,
+        (
+            did,
+            handle,
+            pds_url,
+            authserver_iss,
+            access_token,
+            refresh_token,
+            dpop_authserver_nonce,
+            dpop_private_jwk,
+        ),
+    )
+    conn.commit()
+
+
+def get_oauth_session(conn, did):
+    return conn.execute(
+        "SELECT * FROM oauth_sessions WHERE did = %s", (did,)
+    ).fetchone()
+
+
+def update_oauth_session_tokens(
+    conn, did, access_token, refresh_token, dpop_authserver_nonce
+):
+    conn.execute(
+        """
+        UPDATE oauth_sessions
+        SET access_token = %s, refresh_token = %s, dpop_authserver_nonce = %s
+        WHERE did = %s
+    """,
+        (access_token, refresh_token, dpop_authserver_nonce, did),
+    )
+    conn.commit()
+
+
+def update_oauth_session_pds_nonce(conn, did, dpop_pds_nonce):
+    conn.execute(
+        "UPDATE oauth_sessions SET dpop_pds_nonce = %s WHERE did = %s",
+        (dpop_pds_nonce, did),
+    )
+    conn.commit()
+
+
+def delete_oauth_session(conn, did):
+    conn.execute("DELETE FROM oauth_sessions WHERE did = %s", (did,))
+    conn.commit()
 
 
 def get_activity(conn, did, rkey):

--- a/appview/app/identity.py
+++ b/appview/app/identity.py
@@ -1,0 +1,150 @@
+# Adapted from the AT Protocol OAuth cookbook example:
+# https://github.com/bluesky-social/cookbook/tree/main/python-oauth-web-app
+# Original: atproto_identity.py
+
+import logging
+import re
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+HANDLE_REGEX = re.compile(
+    r"^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$"
+)
+DID_REGEX = re.compile(r"^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]$")
+
+SAFE_HTTP_TIMEOUT = httpx.Timeout(connect=2.0, read=10.0, write=10.0, pool=10.0)
+
+
+def is_valid_handle(handle: str) -> bool:
+    return HANDLE_REGEX.match(handle) is not None
+
+
+def is_valid_did(did: str) -> bool:
+    return DID_REGEX.match(did) is not None
+
+
+def resolve_handle(client: httpx.Client, handle: str) -> str | None:
+    """Resolve an AT Protocol handle to a DID.
+
+    Tries the HTTP well-known method first, then falls back to the XRPC endpoint.
+    """
+    # HTTP well-known
+    try:
+        resp = client.get(
+            f"https://{handle}/.well-known/atproto-did",
+            follow_redirects=False,
+            timeout=SAFE_HTTP_TIMEOUT,
+        )
+        if resp.status_code == 200:
+            did = resp.text.strip().split()[0]
+            if is_valid_did(did):
+                return did
+    except httpx.HTTPError as e:
+        log.debug("HTTP well-known handle resolution failed for %s: %s", handle, e)
+
+    # XRPC fallback
+    try:
+        resp = client.get(
+            "https://bsky.social/xrpc/com.atproto.identity.resolveHandle",
+            params={"handle": handle},
+            timeout=SAFE_HTTP_TIMEOUT,
+        )
+        if resp.status_code == 200:
+            did = resp.json().get("did")
+            if did and is_valid_did(did):
+                return did
+    except httpx.HTTPError as e:
+        log.debug("XRPC handle resolution failed for %s: %s", handle, e)
+
+    return None
+
+
+def resolve_did(client: httpx.Client, did: str) -> dict | None:
+    """Resolve a DID to its DID document."""
+    if did.startswith("did:plc:"):
+        try:
+            resp = client.get(
+                f"https://plc.directory/{did}",
+                timeout=SAFE_HTTP_TIMEOUT,
+            )
+            if resp.status_code == 200:
+                return resp.json()
+        except httpx.HTTPError as e:
+            log.debug("PLC directory resolution failed for %s: %s", did, e)
+        return None
+
+    if did.startswith("did:web:"):
+        domain = did[8:]
+        if not is_valid_handle(domain):
+            log.warning("did:web domain failed validation: %s", domain)
+            return None
+        try:
+            resp = client.get(
+                f"https://{domain}/.well-known/did.json",
+                follow_redirects=False,
+                timeout=SAFE_HTTP_TIMEOUT,
+            )
+            if resp.status_code == 200:
+                return resp.json()
+        except httpx.HTTPError as e:
+            log.debug("did:web resolution failed for %s: %s", did, e)
+        return None
+
+    log.warning("Unsupported DID method: %s", did)
+    return None
+
+
+def pds_endpoint(doc: dict) -> str:
+    """Extract the PDS service endpoint from a DID document."""
+    for svc in doc.get("service", []):
+        if svc.get("id") == "#atproto_pds":
+            return svc["serviceEndpoint"]
+    raise ValueError("No PDS endpoint found in DID document")
+
+
+def handle_from_doc(doc: dict) -> str | None:
+    """Extract the handle from a DID document's alsoKnownAs field."""
+    for aka in doc.get("alsoKnownAs", []):
+        if aka.startswith("at://"):
+            handle = aka[5:]
+            if is_valid_handle(handle):
+                return handle
+    return None
+
+
+def resolve_identity(client: httpx.Client, identifier: str) -> tuple[str, str, str]:
+    """Resolve a handle or DID to a verified (did, handle, pds_url) tuple.
+
+    Performs bi-directional verification: handle -> DID -> handle round-trip.
+    """
+    if is_valid_handle(identifier):
+        handle = identifier
+        did = resolve_handle(client, handle)
+        if not did:
+            raise ValueError(f"Failed to resolve handle: {handle}")
+        doc = resolve_did(client, did)
+        if not doc:
+            raise ValueError(f"Failed to resolve DID: {did}")
+        doc_handle = handle_from_doc(doc)
+        if doc_handle != handle:
+            raise ValueError(f"Handle mismatch: expected {handle}, got {doc_handle}")
+        pds_url = pds_endpoint(doc)
+        return did, handle, pds_url
+
+    if is_valid_did(identifier):
+        did = identifier
+        doc = resolve_did(client, did)
+        if not doc:
+            raise ValueError(f"Failed to resolve DID: {did}")
+        handle = handle_from_doc(doc)
+        if not handle:
+            raise ValueError(f"No handle found in DID document for {did}")
+        verified_did = resolve_handle(client, handle)
+        if verified_did != did:
+            raise ValueError(f"Handle {handle} resolved to {verified_did}, expected {did}")
+        pds_url = pds_endpoint(doc)
+        return did, handle, pds_url
+
+    raise ValueError(f"Identifier is not a valid handle or DID: {identifier}")

--- a/appview/app/main.py
+++ b/appview/app/main.py
@@ -191,6 +191,9 @@ def delete_activity_endpoint(
     rkey: str,
     session: dict = Depends(require_auth),
 ):
+    if did != session["did"]:
+        return JSONResponse(status_code=403, content={"error": "You can only delete your own records"})
+
     pds_url = session["pds_url"]
     url = f"{pds_url}/xrpc/com.atproto.repo.deleteRecord"
     body = {

--- a/appview/app/main.py
+++ b/appview/app/main.py
@@ -1,23 +1,93 @@
-from fastapi import BackgroundTasks, Depends, FastAPI, Query
+import json
+import logging
+from urllib.parse import urlencode, urlparse
+
+import httpx
+from authlib.jose import JsonWebKey
+from fastapi import BackgroundTasks, Depends, FastAPI, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from fastapi.responses import JSONResponse, RedirectResponse
+from starlette.middleware.sessions import SessionMiddleware
 
 from app.auth import require_auth
 from app.backfill import backfill as run_backfill
-from app.backfill import resolve_handle
-from app.db import get_activity as _get
-from app.db import get_connection, init_db
-from app.db import list_activities as _list
+from app.config import get_settings
+from app.db import (
+    delete_activity,
+    delete_auth_request,
+    delete_oauth_session,
+    get_auth_request,
+    get_connection,
+    init_db,
+    save_auth_request,
+    save_oauth_session,
+    update_oauth_session_pds_nonce,
+    update_oauth_session_tokens,
+)
+from app.db import (
+    get_activity as _get,
+)
+from app.db import (
+    list_activities as _list,
+)
+from app.identity import is_valid_did, is_valid_handle, resolve_handle, resolve_identity
+from app.oauth import (
+    fetch_authserver_meta,
+    initial_token_request,
+    is_safe_url,
+    pds_authed_request,
+    refresh_token_request,
+    resolve_pds_authserver,
+    revoke_token_request,
+    send_par_request,
+)
+
+log = logging.getLogger(__name__)
+
+settings = get_settings()
 
 app = FastAPI()
 
+app.add_middleware(SessionMiddleware, secret_key=settings.session_secret_key)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=[settings.frontend_url],
+    allow_credentials=True,
     allow_methods=["GET", "POST"],
     allow_headers=["*"],
 )
+
+# OAuth configuration
+OAUTH_SCOPE = "atproto repo:app.thedistance.activity?action=create repo:app.thedistance.activity?action=update repo:app.thedistance.activity?action=delete"
+
+CLIENT_SECRET_JWK = (
+    JsonWebKey.import_key(json.loads(settings.client_secret_jwk))
+    if settings.client_secret_jwk
+    else None
+)
+CLIENT_PUB_JWK = (
+    json.loads(CLIENT_SECRET_JWK.as_json(is_private=False))
+    if CLIENT_SECRET_JWK
+    else None
+)
+if CLIENT_PUB_JWK:
+    assert "d" not in CLIENT_PUB_JWK, "Public JWK must not contain private key material"
+
+
+def compute_client_id(app_url: str) -> tuple[str, str]:
+    """Compute the OAuth client_id and redirect_uri from the app URL."""
+    parsed = urlparse(app_url)
+    if parsed.hostname == "127.0.0.1":
+        redirect_uri = f"http://127.0.0.1:{parsed.port}/oauth/callback"
+        client_id = "http://localhost?" + urlencode({
+            "redirect_uri": redirect_uri,
+            "scope": OAUTH_SCOPE,
+        })
+    else:
+        url = app_url.rstrip("/")
+        redirect_uri = f"{url}/oauth/callback"
+        client_id = f"{url}/oauth-client-metadata.json"
+    return client_id, redirect_uri
 
 
 def row_to_dict(row):
@@ -28,6 +98,8 @@ def row_to_dict(row):
 def startup():
     init_db()
 
+
+# --- Activity endpoints ---
 
 @app.get("/api/activities")
 def list_activities(
@@ -70,23 +142,330 @@ def get_activity_endpoint(did: str, rkey: str):
         conn.close()
 
 
-class BackfillRequest(BaseModel):
-    handle: str
+# --- Backfill endpoint ---
+
+class BackfillRequest:
+    def __init__(self, handle: str):
+        self.handle = handle
 
 
 @app.post("/api/backfill")
 def backfill_endpoint(
-    req: BackfillRequest,
+    req: dict,
     background_tasks: BackgroundTasks,
-    did: str = Depends(require_auth),
+    session: dict = Depends(require_auth),
 ):
-    import httpx
+    handle = req.get("handle")
+    if not handle:
+        return JSONResponse(status_code=400, content={"error": "handle is required"})
 
     with httpx.Client() as client:
-        handle_did = resolve_handle(client, req.handle)
+        handle_did = resolve_handle(client, handle)
 
-    if handle_did != did:
-        return JSONResponse(status_code=403, content={"error": "You can only backfill your own account"})
+    if handle_did != session["did"]:
+        return JSONResponse(
+            status_code=403, content={"error": "You can only backfill your own account"}
+        )
 
-    background_tasks.add_task(run_backfill, req.handle)
-    return {"status": "started", "handle": req.handle}
+    background_tasks.add_task(run_backfill, handle)
+    return {"status": "started", "handle": handle}
+
+
+# --- Identity endpoints ---
+
+@app.get("/api/resolve/{handle}")
+def resolve_handle_endpoint(handle: str):
+    with httpx.Client() as client:
+        try:
+            did, resolved_handle, pds_url = resolve_identity(client, handle)
+        except ValueError as e:
+            return JSONResponse(status_code=400, content={"error": str(e)})
+    return {"did": did, "handle": resolved_handle}
+
+
+# --- Record management endpoints ---
+
+@app.post("/api/activities/{did}/{rkey}/delete")
+def delete_activity_endpoint(
+    did: str,
+    rkey: str,
+    session: dict = Depends(require_auth),
+):
+    pds_url = session["pds_url"]
+    url = f"{pds_url}/xrpc/com.atproto.repo.deleteRecord"
+    body = {
+        "repo": session["did"],
+        "collection": "app.thedistance.activity",
+        "rkey": rkey,
+    }
+
+    with httpx.Client() as client:
+        resp, dpop_pds_nonce = pds_authed_request(
+            client=client, method="POST", url=url, session=session, body=body,
+        )
+
+    conn = get_connection()
+    try:
+        update_oauth_session_pds_nonce(conn, session["did"], dpop_pds_nonce)
+        if resp.status_code in [200, 201]:
+            delete_activity(conn, did, rkey)
+    finally:
+        conn.close()
+
+    if resp.status_code not in [200, 201]:
+        log.error("PDS delete error: %s", resp.text)
+        return JSONResponse(status_code=resp.status_code, content={"error": "PDS delete failed"})
+
+    return {"status": "deleted"}
+
+
+# --- OAuth endpoints ---
+
+@app.get("/oauth-client-metadata.json")
+def oauth_client_metadata():
+    app_url = settings.app_url.rstrip("/")
+    client_id = f"{app_url}/oauth-client-metadata.json"
+    return {
+        "client_id": client_id,
+        "dpop_bound_access_tokens": True,
+        "application_type": "web",
+        "redirect_uris": [f"{app_url}/oauth/callback"],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "scope": OAUTH_SCOPE,
+        "token_endpoint_auth_method": "private_key_jwt",
+        "token_endpoint_auth_signing_alg": "ES256",
+        "jwks_uri": f"{app_url}/oauth/jwks.json",
+        "client_name": "The Distance",
+        "client_uri": app_url,
+    }
+
+
+@app.get("/oauth/jwks.json")
+def oauth_jwks():
+    if not CLIENT_PUB_JWK:
+        return JSONResponse(status_code=503, content={"error": "OAuth not configured"})
+    return {"keys": [CLIENT_PUB_JWK]}
+
+
+@app.post("/oauth/login")
+def oauth_login(req: dict):
+    if not CLIENT_SECRET_JWK:
+        return JSONResponse(status_code=503, content={"error": "OAuth not configured"})
+
+    username = req.get("username", "").strip()
+    if not username:
+        return JSONResponse(status_code=400, content={"error": "username is required"})
+
+    # Strip @ prefix if present
+    if is_valid_handle(username.removeprefix("@")):
+        username = username.removeprefix("@")
+
+    with httpx.Client() as client:
+        if is_valid_handle(username) or is_valid_did(username):
+            login_hint = username
+            try:
+                did, handle, pds_url = resolve_identity(client, username)
+            except ValueError as e:
+                return JSONResponse(status_code=400, content={"error": str(e)})
+
+            try:
+                authserver_url = resolve_pds_authserver(client, pds_url)
+            except Exception as e:
+                log.error("Failed to resolve auth server for PDS %s: %s", pds_url, e)
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": "Failed to resolve authorization server"},
+                )
+        elif username.startswith("https://") and is_safe_url(username):
+            did, handle, pds_url = None, None, None
+            login_hint = None
+            try:
+                authserver_url = resolve_pds_authserver(client, username)
+            except Exception:
+                authserver_url = username.rstrip("/")
+        else:
+            return JSONResponse(
+                status_code=400,
+                content={"error": "Not a valid handle, DID, or auth server URL"},
+            )
+
+        try:
+            authserver_meta = fetch_authserver_meta(client, authserver_url)
+        except Exception as e:
+            log.error("Failed to fetch auth server metadata: %s", e)
+            return JSONResponse(
+                status_code=400,
+                content={"error": "Failed to fetch authorization server metadata"},
+            )
+
+        dpop_private_jwk = JsonWebKey.generate_key("EC", "P-256", is_private=True)
+        client_id, redirect_uri = compute_client_id(settings.app_url)
+
+        pkce_verifier, state, dpop_authserver_nonce, resp = send_par_request(
+            client=client,
+            authserver_url=authserver_url,
+            authserver_meta=authserver_meta,
+            login_hint=login_hint,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            scope=OAUTH_SCOPE,
+            client_secret_jwk=CLIENT_SECRET_JWK,
+            dpop_private_jwk=dpop_private_jwk,
+        )
+
+    if resp.status_code == 400:
+        log.error("PAR HTTP 400: %s", resp.json())
+    resp.raise_for_status()
+
+    par_request_uri = resp.json()["request_uri"]
+
+    conn = get_connection()
+    try:
+        save_auth_request(
+            conn, state, authserver_meta["issuer"], did, handle, pds_url,
+            pkce_verifier, OAUTH_SCOPE, dpop_authserver_nonce,
+            dpop_private_jwk.as_json(is_private=True),
+        )
+    finally:
+        conn.close()
+
+    auth_url = authserver_meta["authorization_endpoint"]
+    if not is_safe_url(auth_url):
+        return JSONResponse(status_code=400, content={"error": "Unsafe authorization URL"})
+    qparam = urlencode({"client_id": client_id, "request_uri": par_request_uri})
+    return {"redirect_url": f"{auth_url}?{qparam}"}
+
+
+@app.get("/oauth/callback")
+def oauth_callback(request: Request):
+    if not CLIENT_SECRET_JWK:
+        return JSONResponse(status_code=503, content={"error": "OAuth not configured"})
+
+    error = request.query_params.get("error")
+    if error:
+        desc = request.query_params.get("error_description", "")
+        return JSONResponse(status_code=400, content={"error": f"{error}: {desc}"})
+
+    state = request.query_params.get("state")
+    authserver_iss = request.query_params.get("iss")
+    code = request.query_params.get("code")
+
+    if not all([state, authserver_iss, code]):
+        return JSONResponse(status_code=400, content={"error": "Missing callback parameters"})
+
+    conn = get_connection()
+    try:
+        auth_req = get_auth_request(conn, state)
+        if not auth_req:
+            return JSONResponse(status_code=400, content={"error": "OAuth request not found"})
+
+        delete_auth_request(conn, state)
+
+        if auth_req["authserver_iss"] != authserver_iss:
+            return JSONResponse(
+                status_code=400, content={"error": "Authorization server mismatch"}
+            )
+
+        client_id, redirect_uri = compute_client_id(settings.app_url)
+
+        with httpx.Client() as client:
+            tokens, dpop_authserver_nonce = initial_token_request(
+                client=client,
+                auth_request=auth_req,
+                code=code,
+                client_id=client_id,
+                redirect_uri=redirect_uri,
+                client_secret_jwk=CLIENT_SECRET_JWK,
+            )
+
+            log.info("Token response scopes: %s", tokens.get("scope"))
+
+            if auth_req["did"]:
+                did = auth_req["did"]
+                handle = auth_req["handle"]
+                pds_url = auth_req["pds_url"]
+                if tokens["sub"] != did:
+                    return JSONResponse(
+                        status_code=400, content={"error": "DID mismatch in token response"}
+                    )
+            else:
+                did = tokens["sub"]
+                if not is_valid_did(did):
+                    return JSONResponse(
+                        status_code=400, content={"error": "Invalid DID in token response"}
+                    )
+                did, handle, pds_url = resolve_identity(client, did)
+                verified_authserver = resolve_pds_authserver(client, pds_url)
+                if verified_authserver != authserver_iss:
+                    return JSONResponse(
+                        status_code=400, content={"error": "Authorization server mismatch"}
+                    )
+
+        save_oauth_session(
+            conn, did, handle, pds_url, authserver_iss,
+            tokens["access_token"], tokens["refresh_token"],
+            dpop_authserver_nonce, auth_req["dpop_private_jwk"],
+        )
+    finally:
+        conn.close()
+
+    request.session["user_did"] = did
+    request.session["user_handle"] = handle
+
+    return RedirectResponse(url=settings.frontend_url, status_code=302)
+
+
+@app.post("/oauth/refresh")
+def oauth_refresh(request: Request, session: dict = Depends(require_auth)):
+    client_id, _ = compute_client_id(settings.app_url)
+
+    with httpx.Client() as client:
+        tokens, dpop_authserver_nonce = refresh_token_request(
+            client=client,
+            session=session,
+            client_id=client_id,
+            client_secret_jwk=CLIENT_SECRET_JWK,
+        )
+
+    conn = get_connection()
+    try:
+        update_oauth_session_tokens(
+            conn, session["did"],
+            tokens["access_token"], tokens["refresh_token"],
+            dpop_authserver_nonce,
+        )
+    finally:
+        conn.close()
+
+    return {"status": "refreshed"}
+
+
+@app.post("/oauth/logout")
+def oauth_logout(request: Request, session: dict = Depends(require_auth)):
+    client_id, _ = compute_client_id(settings.app_url)
+
+    with httpx.Client() as client:
+        try:
+            revoke_token_request(
+                client=client,
+                session=session,
+                client_id=client_id,
+                client_secret_jwk=CLIENT_SECRET_JWK,
+            )
+        except Exception as e:
+            log.error("Error during token revocation: %s", e)
+
+    conn = get_connection()
+    try:
+        delete_oauth_session(conn, session["did"])
+    finally:
+        conn.close()
+
+    request.session.clear()
+    return {"status": "logged out"}
+
+
+@app.get("/oauth/me")
+def oauth_me(session: dict = Depends(require_auth)):
+    return {"did": session["did"], "handle": session["handle"]}

--- a/appview/app/oauth.py
+++ b/appview/app/oauth.py
@@ -1,0 +1,490 @@
+# Adapted from the AT Protocol OAuth cookbook example:
+# https://github.com/bluesky-social/cookbook/tree/main/python-oauth-web-app
+# Original: atproto_oauth.py, atproto_security.py
+
+import json
+import logging
+import time
+import urllib.request
+from urllib.parse import urlparse
+
+import httpx
+from authlib.common.security import generate_token
+from authlib.jose import JsonWebKey, jwt
+from authlib.oauth2.rfc7636 import create_s256_code_challenge
+
+log = logging.getLogger(__name__)
+
+SAFE_HTTP_TIMEOUT = httpx.Timeout(connect=2.0, read=10.0, write=10.0, pool=10.0)
+
+
+def is_safe_url(url: str) -> bool:
+    """Check that a URL looks safe for server-side requests (SSRF mitigation).
+
+    This is a partial filter. The httpx client's own protections provide
+    additional coverage.
+    """
+    parts = urlparse(url)
+    if not (
+        parts.scheme == "https"
+        and parts.hostname is not None
+        and parts.hostname == parts.netloc
+        and parts.username is None
+        and parts.password is None
+        and parts.port is None
+    ):
+        return False
+
+    segments = parts.hostname.split(".")
+    if not (
+        len(segments) >= 2
+        and segments[-1] not in ["local", "arpa", "internal", "localhost"]
+    ):
+        return False
+
+    if segments[-1].isdigit():
+        return False
+
+    return True
+
+
+def validate_authserver_meta(meta: dict, url: str) -> None:
+    """Validate Authorization Server metadata against AT Protocol OAuth requirements.
+
+    Raises ValueError if any requirement is not met.
+    """
+    fetch_url = urlparse(url)
+    issuer_url = urlparse(meta.get("issuer", ""))
+
+    checks = [
+        (issuer_url.hostname == fetch_url.hostname, "issuer hostname mismatch"),
+        (issuer_url.scheme == "https", "issuer must be HTTPS"),
+        (issuer_url.port is None, "issuer must not specify port"),
+        (issuer_url.path in ["", "/"], "issuer must not have path"),
+        (issuer_url.fragment == "", "issuer must not have fragment"),
+        ("code" in meta.get("response_types_supported", []), "code response type required"),
+        (
+            "authorization_code" in meta.get("grant_types_supported", []),
+            "authorization_code grant required",
+        ),
+        (
+            "refresh_token" in meta.get("grant_types_supported", []),
+            "refresh_token grant required",
+        ),
+        ("S256" in meta.get("code_challenge_methods_supported", []), "S256 PKCE required"),
+        (
+            "private_key_jwt" in meta.get("token_endpoint_auth_methods_supported", []),
+            "private_key_jwt auth method required",
+        ),
+        (
+            "ES256" in meta.get("token_endpoint_auth_signing_alg_values_supported", []),
+            "ES256 signing required",
+        ),
+        ("atproto" in meta.get("scopes_supported", []), "atproto scope required"),
+        (
+            meta.get("authorization_response_iss_parameter_supported") is True,
+            "ISS parameter support required",
+        ),
+        (
+            meta.get("pushed_authorization_request_endpoint") is not None,
+            "PAR endpoint required",
+        ),
+        (
+            meta.get("require_pushed_authorization_requests") is True,
+            "PAR must be required",
+        ),
+        ("ES256" in meta.get("dpop_signing_alg_values_supported", []), "ES256 DPoP required"),
+        (
+            meta.get("client_id_metadata_document_supported") is True,
+            "client_id metadata document support required",
+        ),
+    ]
+
+    for condition, message in checks:
+        if not condition:
+            raise ValueError(f"Invalid auth server metadata: {message}")
+
+
+def resolve_pds_authserver(client: httpx.Client, pds_url: str) -> str:
+    """Resolve a PDS URL to its Authorization Server URL."""
+    if not is_safe_url(pds_url):
+        raise ValueError(f"Unsafe PDS URL: {pds_url}")
+    resp = client.get(
+        f"{pds_url}/.well-known/oauth-protected-resource",
+        follow_redirects=False,
+        timeout=SAFE_HTTP_TIMEOUT,
+    )
+    resp.raise_for_status()
+    if resp.status_code != 200:
+        raise ValueError(f"Unexpected status {resp.status_code} from PDS oauth-protected-resource")
+    return resp.json()["authorization_servers"][0]
+
+
+def fetch_authserver_meta(client: httpx.Client, url: str) -> dict:
+    """Fetch and validate Authorization Server metadata."""
+    if not is_safe_url(url):
+        raise ValueError(f"Unsafe auth server URL: {url}")
+    resp = client.get(
+        f"{url}/.well-known/oauth-authorization-server",
+        follow_redirects=False,
+        timeout=SAFE_HTTP_TIMEOUT,
+    )
+    resp.raise_for_status()
+    meta = resp.json()
+    validate_authserver_meta(meta, url)
+    return meta
+
+
+def client_assertion_jwt(
+    client_id: str, authserver_url: str, client_secret_jwk: JsonWebKey
+) -> str:
+    """Create a self-signed client assertion JWT for auth server requests."""
+    now = int(time.time())
+    return jwt.encode(
+        {"alg": "ES256", "kid": client_secret_jwk["kid"]},
+        {
+            "iss": client_id,
+            "sub": client_id,
+            "aud": authserver_url,
+            "jti": generate_token(),
+            "iat": now,
+            "exp": now + 60,
+        },
+        client_secret_jwk,
+    ).decode("utf-8")
+
+
+def _dpop_jwt(
+    method: str,
+    url: str,
+    nonce: str,
+    dpop_private_jwk: JsonWebKey,
+    access_token: str | None = None,
+    expiry: int = 30,
+) -> str:
+    """Create a DPoP proof JWT.
+
+    When access_token is provided, includes an 'ath' (access token hash) claim
+    for resource server (PDS) requests.
+    """
+    dpop_pub_jwk = json.loads(dpop_private_jwk.as_json(is_private=False))
+    now = int(time.time())
+    body = {
+        "jti": generate_token(),
+        "htm": method,
+        "htu": url,
+        "iat": now,
+        "exp": now + expiry,
+    }
+    if nonce:
+        body["nonce"] = nonce
+    if access_token:
+        body["ath"] = create_s256_code_challenge(access_token)
+    return jwt.encode(
+        {"typ": "dpop+jwt", "alg": "ES256", "jwk": dpop_pub_jwk},
+        body,
+        dpop_private_jwk,
+    ).decode("utf-8")
+
+
+def _parse_www_authenticate(data: str) -> tuple[str, dict]:
+    """Minimal WWW-Authenticate header parser for DPoP nonce errors."""
+    scheme, _, params = data.partition(" ")
+    items = urllib.request.parse_http_list(params)
+    opts = urllib.request.parse_keqv_list(items)
+    return scheme, opts
+
+
+def _is_dpop_nonce_error(resp: httpx.Response) -> bool:
+    """Check if a response indicates a DPoP nonce is needed or has changed.
+
+    Servers signal this via either:
+    1. WWW-Authenticate header with error="use_dpop_nonce"
+    2. JSON response body with error="use_dpop_nonce"
+    """
+    if resp.status_code not in [400, 401]:
+        return False
+
+    www_auth = resp.headers.get("WWW-Authenticate")
+    if www_auth:
+        try:
+            scheme, params = _parse_www_authenticate(www_auth)
+            if scheme.lower() == "dpop" and params.get("error") == "use_dpop_nonce":
+                return True
+        except Exception:
+            pass
+
+    try:
+        body = resp.json()
+        if isinstance(body, dict) and body.get("error") == "use_dpop_nonce":
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
+def _authserver_post(
+    client: httpx.Client,
+    authserver_url: str,
+    client_id: str,
+    client_secret_jwk: JsonWebKey,
+    dpop_private_jwk: JsonWebKey,
+    dpop_nonce: str,
+    post_url: str,
+    post_data: dict,
+) -> tuple[str, httpx.Response]:
+    """POST to an auth server endpoint with client assertion and DPoP proof.
+
+    Handles DPoP nonce errors by retrying once with the server-provided nonce.
+    Returns the (possibly updated) DPoP nonce and the response.
+    """
+    assertion = client_assertion_jwt(client_id, authserver_url, client_secret_jwk)
+    post_data = {
+        **post_data,
+        "client_id": client_id,
+        "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+        "client_assertion": assertion,
+    }
+
+    if not is_safe_url(post_url):
+        raise ValueError(f"Unsafe auth server URL: {post_url}")
+
+    dpop_proof = _dpop_jwt("POST", post_url, dpop_nonce, dpop_private_jwk)
+    resp = client.post(
+        post_url,
+        data=post_data,
+        headers={"DPoP": dpop_proof},
+        follow_redirects=False,
+        timeout=SAFE_HTTP_TIMEOUT,
+    )
+
+    if _is_dpop_nonce_error(resp):
+        dpop_nonce = resp.headers["DPoP-Nonce"]
+        log.debug("Retrying with new auth server DPoP nonce")
+        dpop_proof = _dpop_jwt("POST", post_url, dpop_nonce, dpop_private_jwk)
+        resp = client.post(
+            post_url,
+            data=post_data,
+            headers={"DPoP": dpop_proof},
+            follow_redirects=False,
+            timeout=SAFE_HTTP_TIMEOUT,
+        )
+
+    return dpop_nonce, resp
+
+
+def send_par_request(
+    client: httpx.Client,
+    authserver_url: str,
+    authserver_meta: dict,
+    login_hint: str | None,
+    client_id: str,
+    redirect_uri: str,
+    scope: str,
+    client_secret_jwk: JsonWebKey,
+    dpop_private_jwk: JsonWebKey,
+) -> tuple[str, str, str, httpx.Response]:
+    """Send a Pushed Authorization Request (PAR).
+
+    Returns (pkce_verifier, state, dpop_nonce, response).
+    """
+    par_url = authserver_meta["pushed_authorization_request_endpoint"]
+    if not is_safe_url(par_url):
+        raise ValueError(f"Unsafe PAR URL: {par_url}")
+
+    state = generate_token()
+    pkce_verifier = generate_token(48)
+    code_challenge = create_s256_code_challenge(pkce_verifier)
+
+    par_body = {
+        "response_type": "code",
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+        "redirect_uri": redirect_uri,
+        "scope": scope,
+    }
+    if login_hint:
+        par_body["login_hint"] = login_hint
+
+    dpop_nonce, resp = _authserver_post(
+        client=client,
+        authserver_url=authserver_url,
+        client_id=client_id,
+        client_secret_jwk=client_secret_jwk,
+        dpop_private_jwk=dpop_private_jwk,
+        dpop_nonce="",
+        post_url=par_url,
+        post_data=par_body,
+    )
+
+    return pkce_verifier, state, dpop_nonce, resp
+
+
+def initial_token_request(
+    client: httpx.Client,
+    auth_request: dict,
+    code: str,
+    client_id: str,
+    redirect_uri: str,
+    client_secret_jwk: JsonWebKey,
+) -> tuple[dict, str]:
+    """Exchange an authorization code for tokens.
+
+    Returns (token_response, dpop_nonce).
+    The caller must verify token_response["sub"] matches the expected DID.
+    """
+    authserver_url = auth_request["authserver_iss"]
+    authserver_meta = fetch_authserver_meta(client, authserver_url)
+    token_url = authserver_meta["token_endpoint"]
+
+    if not is_safe_url(token_url):
+        raise ValueError(f"Unsafe token URL: {token_url}")
+
+    dpop_private_jwk = JsonWebKey.import_key(json.loads(auth_request["dpop_private_jwk"]))
+
+    dpop_nonce, resp = _authserver_post(
+        client=client,
+        authserver_url=authserver_url,
+        client_id=client_id,
+        client_secret_jwk=client_secret_jwk,
+        dpop_private_jwk=dpop_private_jwk,
+        dpop_nonce=auth_request["dpop_authserver_nonce"],
+        post_url=token_url,
+        post_data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "code_verifier": auth_request["pkce_verifier"],
+            "redirect_uri": redirect_uri,
+        },
+    )
+
+    resp.raise_for_status()
+    return resp.json(), dpop_nonce
+
+
+def refresh_token_request(
+    client: httpx.Client,
+    session: dict,
+    client_id: str,
+    client_secret_jwk: JsonWebKey,
+) -> tuple[dict, str]:
+    """Refresh an access token.
+
+    Returns (token_response, dpop_nonce).
+    """
+    authserver_url = session["authserver_iss"]
+    authserver_meta = fetch_authserver_meta(client, authserver_url)
+    token_url = authserver_meta["token_endpoint"]
+
+    if not is_safe_url(token_url):
+        raise ValueError(f"Unsafe token URL: {token_url}")
+
+    dpop_private_jwk = JsonWebKey.import_key(json.loads(session["dpop_private_jwk"]))
+
+    dpop_nonce, resp = _authserver_post(
+        client=client,
+        authserver_url=authserver_url,
+        client_id=client_id,
+        client_secret_jwk=client_secret_jwk,
+        dpop_private_jwk=dpop_private_jwk,
+        dpop_nonce=session["dpop_authserver_nonce"],
+        post_url=token_url,
+        post_data={
+            "grant_type": "refresh_token",
+            "refresh_token": session["refresh_token"],
+        },
+    )
+
+    if resp.status_code not in [200, 201]:
+        log.error("Token refresh error: %s", resp.json())
+    resp.raise_for_status()
+    return resp.json(), dpop_nonce
+
+
+def revoke_token_request(
+    client: httpx.Client,
+    session: dict,
+    client_id: str,
+    client_secret_jwk: JsonWebKey,
+) -> None:
+    """Revoke access and refresh tokens."""
+    authserver_url = session["authserver_iss"]
+    authserver_meta = fetch_authserver_meta(client, authserver_url)
+
+    revoke_url = authserver_meta.get("revocation_endpoint")
+    if not revoke_url:
+        log.info("Auth server does not support token revocation")
+        return
+
+    if not is_safe_url(revoke_url):
+        raise ValueError(f"Unsafe revocation URL: {revoke_url}")
+
+    dpop_private_jwk = JsonWebKey.import_key(json.loads(session["dpop_private_jwk"]))
+    dpop_nonce = session["dpop_authserver_nonce"]
+
+    for token_type in ["access_token", "refresh_token"]:
+        dpop_nonce, resp = _authserver_post(
+            client=client,
+            authserver_url=authserver_url,
+            client_id=client_id,
+            client_secret_jwk=client_secret_jwk,
+            dpop_private_jwk=dpop_private_jwk,
+            dpop_nonce=dpop_nonce,
+            post_url=revoke_url,
+            post_data={
+                "token": session[token_type],
+                "token_type_hint": token_type,
+            },
+        )
+        resp.raise_for_status()
+
+
+def pds_authed_request(
+    client: httpx.Client,
+    method: str,
+    url: str,
+    session: dict,
+    body: dict | None = None,
+) -> tuple[httpx.Response, str]:
+    """Make an authenticated request to a user's PDS.
+
+    Returns (response, updated_dpop_pds_nonce). The caller is responsible for
+    persisting the updated nonce.
+    """
+    dpop_private_jwk = JsonWebKey.import_key(json.loads(session["dpop_private_jwk"]))
+    dpop_pds_nonce = session.get("dpop_pds_nonce") or ""
+    access_token = session["access_token"]
+
+    for _ in range(2):
+        dpop_proof = _dpop_jwt(
+            method,
+            url,
+            dpop_pds_nonce,
+            dpop_private_jwk,
+            access_token=access_token,
+            expiry=10,
+        )
+
+        headers = {
+            "Authorization": f"DPoP {access_token}",
+            "DPoP": dpop_proof,
+        }
+
+        if method.upper() == "GET":
+            resp = client.get(
+                url, headers=headers, follow_redirects=False, timeout=SAFE_HTTP_TIMEOUT
+            )
+        else:
+            resp = client.post(
+                url, headers=headers, json=body, follow_redirects=False, timeout=SAFE_HTTP_TIMEOUT
+            )
+
+        if _is_dpop_nonce_error(resp):
+            dpop_pds_nonce = resp.headers["DPoP-Nonce"]
+            log.debug("Retrying with new PDS DPoP nonce")
+            continue
+        break
+
+    return resp, dpop_pds_nonce

--- a/appview/pyproject.toml
+++ b/appview/pyproject.toml
@@ -11,12 +11,15 @@ dependencies = [
   "python-dotenv>=1.0",
   "pydantic-settings>=2.6",
   "httpx>=0.28",
+  "authlib>=1.3",
+  "itsdangerous>=2.1",
 ]
 
 [project.scripts]
 start = "app.cli:start"
 subscribe = "app.cli:subscribe"
 backfill = "app.cli:backfill"
+generate-jwk = "app.cli:generate_jwk"
 
 [build-system]
 requires = ["hatchling"]

--- a/appview/uv.lock
+++ b/appview/uv.lock
@@ -34,12 +34,81 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.6.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -61,6 +130,59 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/ba/04b1bd4218cbc58dc90ce967106d51582371b898690f3ae0402876cc4f34/cryptography-46.0.6.tar.gz", hash = "sha256:27550628a518c5c6c903d84f637fbecf287f6cb9ced3804838a1295dc1fd0759", size = 750542, upload-time = "2026-03-25T23:34:53.396Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/23/9285e15e3bc57325b0a72e592921983a701efc1ee8f91c06c5f0235d86d9/cryptography-46.0.6-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:64235194bad039a10bb6d2d930ab3323baaec67e2ce36215fd0952fad0930ca8", size = 7176401, upload-time = "2026-03-25T23:33:22.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/e61f8f13950ab6195b31913b42d39f0f9afc7d93f76710f299b5ec286ae6/cryptography-46.0.6-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:26031f1e5ca62fcb9d1fcb34b2b60b390d1aacaa15dc8b895a9ed00968b97b30", size = 4275275, upload-time = "2026-03-25T23:33:23.844Z" },
+    { url = "https://files.pythonhosted.org/packages/19/69/732a736d12c2631e140be2348b4ad3d226302df63ef64d30dfdb8db7ad1c/cryptography-46.0.6-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9a693028b9cbe51b5a1136232ee8f2bc242e4e19d456ded3fa7c86e43c713b4a", size = 4425320, upload-time = "2026-03-25T23:33:25.703Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/12/123be7292674abf76b21ac1fc0e1af50661f0e5b8f0ec8285faac18eb99e/cryptography-46.0.6-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:67177e8a9f421aa2d3a170c3e56eca4e0128883cf52a071a7cbf53297f18b175", size = 4278082, upload-time = "2026-03-25T23:33:27.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ba/d5e27f8d68c24951b0a484924a84c7cdaed7502bac9f18601cd357f8b1d2/cryptography-46.0.6-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d9528b535a6c4f8ff37847144b8986a9a143585f0540fbcb1a98115b543aa463", size = 4926514, upload-time = "2026-03-25T23:33:29.206Z" },
+    { url = "https://files.pythonhosted.org/packages/34/71/1ea5a7352ae516d5512d17babe7e1b87d9db5150b21f794b1377eac1edc0/cryptography-46.0.6-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:22259338084d6ae497a19bae5d4c66b7ca1387d3264d1c2c0e72d9e9b6a77b97", size = 4457766, upload-time = "2026-03-25T23:33:30.834Z" },
+    { url = "https://files.pythonhosted.org/packages/01/59/562be1e653accee4fdad92c7a2e88fced26b3fdfce144047519bbebc299e/cryptography-46.0.6-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:760997a4b950ff00d418398ad73fbc91aa2894b5c1db7ccb45b4f68b42a63b3c", size = 3986535, upload-time = "2026-03-25T23:33:33.02Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/8b/b1ebfeb788bf4624d36e45ed2662b8bd43a05ff62157093c1539c1288a18/cryptography-46.0.6-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:3dfa6567f2e9e4c5dceb8ccb5a708158a2a871052fa75c8b78cb0977063f1507", size = 4277618, upload-time = "2026-03-25T23:33:34.567Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/52/a005f8eabdb28df57c20f84c44d397a755782d6ff6d455f05baa2785bd91/cryptography-46.0.6-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:cdcd3edcbc5d55757e5f5f3d330dd00007ae463a7e7aa5bf132d1f22a4b62b19", size = 4890802, upload-time = "2026-03-25T23:33:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/4d/8e7d7245c79c617d08724e2efa397737715ca0ec830ecb3c91e547302555/cryptography-46.0.6-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:d4e4aadb7fc1f88687f47ca20bb7227981b03afaae69287029da08096853b738", size = 4457425, upload-time = "2026-03-25T23:33:38.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/5c/f6c3596a1430cec6f949085f0e1a970638d76f81c3ea56d93d564d04c340/cryptography-46.0.6-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2b417edbe8877cda9022dde3a008e2deb50be9c407eef034aeeb3a8b11d9db3c", size = 4405530, upload-time = "2026-03-25T23:33:40.842Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/c9/9f9cea13ee2dbde070424e0c4f621c091a91ffcc504ffea5e74f0e1daeff/cryptography-46.0.6-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:380343e0653b1c9d7e1f55b52aaa2dbb2fdf2730088d48c43ca1c7c0abb7cc2f", size = 4667896, upload-time = "2026-03-25T23:33:42.781Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/b5/1895bc0821226f129bc74d00eccfc6a5969e2028f8617c09790bf89c185e/cryptography-46.0.6-cp311-abi3-win32.whl", hash = "sha256:bcb87663e1f7b075e48c3be3ecb5f0b46c8fc50b50a97cf264e7f60242dca3f2", size = 3026348, upload-time = "2026-03-25T23:33:45.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f8/c9bcbf0d3e6ad288b9d9aa0b1dee04b063d19e8c4f871855a03ab3a297ab/cryptography-46.0.6-cp311-abi3-win_amd64.whl", hash = "sha256:6739d56300662c468fddb0e5e291f9b4d084bead381667b9e654c7dd81705124", size = 3483896, upload-time = "2026-03-25T23:33:46.649Z" },
+    { url = "https://files.pythonhosted.org/packages/01/41/3a578f7fd5c70611c0aacba52cd13cb364a5dee895a5c1d467208a9380b0/cryptography-46.0.6-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:2ef9e69886cbb137c2aef9772c2e7138dc581fad4fcbcf13cc181eb5a3ab6275", size = 7117147, upload-time = "2026-03-25T23:33:48.249Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/87/887f35a6fca9dde90cad08e0de0c89263a8e59b2d2ff904fd9fcd8025b6f/cryptography-46.0.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7f417f034f91dcec1cb6c5c35b07cdbb2ef262557f701b4ecd803ee8cefed4f4", size = 4266221, upload-time = "2026-03-25T23:33:49.874Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a8/0a90c4f0b0871e0e3d1ed126aed101328a8a57fd9fd17f00fb67e82a51ca/cryptography-46.0.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d24c13369e856b94892a89ddf70b332e0b70ad4a5c43cf3e9cb71d6d7ffa1f7b", size = 4408952, upload-time = "2026-03-25T23:33:52.128Z" },
+    { url = "https://files.pythonhosted.org/packages/16/0b/b239701eb946523e4e9f329336e4ff32b1247e109cbab32d1a7b61da8ed7/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:aad75154a7ac9039936d50cf431719a2f8d4ed3d3c277ac03f3339ded1a5e707", size = 4270141, upload-time = "2026-03-25T23:33:54.11Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a8/976acdd4f0f30df7b25605f4b9d3d89295351665c2091d18224f7ad5cdbf/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3c21d92ed15e9cfc6eb64c1f5a0326db22ca9c2566ca46d845119b45b4400361", size = 4904178, upload-time = "2026-03-25T23:33:55.725Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1b/bf0e01a88efd0e59679b69f42d4afd5bced8700bb5e80617b2d63a3741af/cryptography-46.0.6-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4668298aef7cddeaf5c6ecc244c2302a2b8e40f384255505c22875eebb47888b", size = 4441812, upload-time = "2026-03-25T23:33:57.364Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/8b/11df86de2ea389c65aa1806f331cae145f2ed18011f30234cc10ca253de8/cryptography-46.0.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8ce35b77aaf02f3b59c90b2c8a05c73bac12cea5b4e8f3fbece1f5fddea5f0ca", size = 3963923, upload-time = "2026-03-25T23:33:59.361Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e0/207fb177c3a9ef6a8108f234208c3e9e76a6aa8cf20d51932916bd43bda0/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:c89eb37fae9216985d8734c1afd172ba4927f5a05cfd9bf0e4863c6d5465b013", size = 4269695, upload-time = "2026-03-25T23:34:00.909Z" },
+    { url = "https://files.pythonhosted.org/packages/21/5e/19f3260ed1e95bced52ace7501fabcd266df67077eeb382b79c81729d2d3/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:ed418c37d095aeddf5336898a132fba01091f0ac5844e3e8018506f014b6d2c4", size = 4869785, upload-time = "2026-03-25T23:34:02.796Z" },
+    { url = "https://files.pythonhosted.org/packages/10/38/cd7864d79aa1d92ef6f1a584281433419b955ad5a5ba8d1eb6c872165bcb/cryptography-46.0.6-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:69cf0056d6947edc6e6760e5f17afe4bea06b56a9ac8a06de9d2bd6b532d4f3a", size = 4441404, upload-time = "2026-03-25T23:34:04.35Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0a/4fe7a8d25fed74419f91835cf5829ade6408fd1963c9eae9c4bce390ecbb/cryptography-46.0.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8e7304c4f4e9490e11efe56af6713983460ee0780f16c63f219984dab3af9d2d", size = 4397549, upload-time = "2026-03-25T23:34:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a0/7d738944eac6513cd60a8da98b65951f4a3b279b93479a7e8926d9cd730b/cryptography-46.0.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b928a3ca837c77a10e81a814a693f2295200adb3352395fad024559b7be7a736", size = 4651874, upload-time = "2026-03-25T23:34:07.916Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/f1/c2326781ca05208845efca38bf714f76939ae446cd492d7613808badedf1/cryptography-46.0.6-cp314-cp314t-win32.whl", hash = "sha256:97c8115b27e19e592a05c45d0dd89c57f81f841cc9880e353e0d3bf25b2139ed", size = 3001511, upload-time = "2026-03-25T23:34:09.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/57/fe4a23eb549ac9d903bd4698ffda13383808ef0876cc912bcb2838799ece/cryptography-46.0.6-cp314-cp314t-win_amd64.whl", hash = "sha256:c797e2517cb7880f8297e2c0f43bb910e91381339336f75d2c1c2cbf811b70b4", size = 3471692, upload-time = "2026-03-25T23:34:11.613Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/cc/f330e982852403da79008552de9906804568ae9230da8432f7496ce02b71/cryptography-46.0.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:12cae594e9473bca1a7aceb90536060643128bb274fcea0fc459ab90f7d1ae7a", size = 7162776, upload-time = "2026-03-25T23:34:13.308Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b3/dc27efd8dcc4bff583b3f01d4a3943cd8b5821777a58b3a6a5f054d61b79/cryptography-46.0.6-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:639301950939d844a9e1c4464d7e07f902fe9a7f6b215bb0d4f28584729935d8", size = 4270529, upload-time = "2026-03-25T23:34:15.019Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/05/e8d0e6eb4f0d83365b3cb0e00eb3c484f7348db0266652ccd84632a3d58d/cryptography-46.0.6-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ed3775295fb91f70b4027aeba878d79b3e55c0b3e97eaa4de71f8f23a9f2eb77", size = 4414827, upload-time = "2026-03-25T23:34:16.604Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/97/daba0f5d2dc6d855e2dcb70733c812558a7977a55dd4a6722756628c44d1/cryptography-46.0.6-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:8927ccfbe967c7df312ade694f987e7e9e22b2425976ddbf28271d7e58845290", size = 4271265, upload-time = "2026-03-25T23:34:18.586Z" },
+    { url = "https://files.pythonhosted.org/packages/89/06/fe1fce39a37ac452e58d04b43b0855261dac320a2ebf8f5260dd55b201a9/cryptography-46.0.6-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:b12c6b1e1651e42ab5de8b1e00dc3b6354fdfd778e7fa60541ddacc27cd21410", size = 4916800, upload-time = "2026-03-25T23:34:20.561Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8a/b14f3101fe9c3592603339eb5d94046c3ce5f7fc76d6512a2d40efd9724e/cryptography-46.0.6-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:063b67749f338ca9c5a0b7fe438a52c25f9526b851e24e6c9310e7195aad3b4d", size = 4448771, upload-time = "2026-03-25T23:34:22.406Z" },
+    { url = "https://files.pythonhosted.org/packages/01/b3/0796998056a66d1973fd52ee89dc1bb3b6581960a91ad4ac705f182d398f/cryptography-46.0.6-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:02fad249cb0e090b574e30b276a3da6a149e04ee2f049725b1f69e7b8351ec70", size = 3978333, upload-time = "2026-03-25T23:34:24.281Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3d/db200af5a4ffd08918cd55c08399dc6c9c50b0bc72c00a3246e099d3a849/cryptography-46.0.6-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e6142674f2a9291463e5e150090b95a8519b2fb6e6aaec8917dd8d094ce750d", size = 4271069, upload-time = "2026-03-25T23:34:25.895Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/18/61acfd5b414309d74ee838be321c636fe71815436f53c9f0334bf19064fa/cryptography-46.0.6-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:456b3215172aeefb9284550b162801d62f5f264a081049a3e94307fe20792cfa", size = 4878358, upload-time = "2026-03-25T23:34:27.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/65/5bf43286d566f8171917cae23ac6add941654ccf085d739195a4eacf1674/cryptography-46.0.6-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:341359d6c9e68834e204ceaf25936dffeafea3829ab80e9503860dcc4f4dac58", size = 4448061, upload-time = "2026-03-25T23:34:29.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/25/7e49c0fa7205cf3597e525d156a6bce5b5c9de1fd7e8cb01120e459f205a/cryptography-46.0.6-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9a9c42a2723999a710445bc0d974e345c32adfd8d2fac6d8a251fa829ad31cfb", size = 4399103, upload-time = "2026-03-25T23:34:32.036Z" },
+    { url = "https://files.pythonhosted.org/packages/44/46/466269e833f1c4718d6cd496ffe20c56c9c8d013486ff66b4f69c302a68d/cryptography-46.0.6-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6617f67b1606dfd9fe4dbfa354a9508d4a6d37afe30306fe6c101b7ce3274b72", size = 4659255, upload-time = "2026-03-25T23:34:33.679Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/09/ddc5f630cc32287d2c953fc5d32705e63ec73e37308e5120955316f53827/cryptography-46.0.6-cp38-abi3-win32.whl", hash = "sha256:7f6690b6c55e9c5332c0b59b9c8a3fb232ebf059094c17f9019a51e9827df91c", size = 3010660, upload-time = "2026-03-25T23:34:35.418Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/82/ca4893968aeb2709aacfb57a30dec6fa2ab25b10fa9f064b8882ce33f599/cryptography-46.0.6-cp38-abi3-win_amd64.whl", hash = "sha256:79e865c642cfc5c0b3eb12af83c35c5aeff4fa5c672dc28c43721c2c9fdd2f0f", size = 3471160, upload-time = "2026-03-25T23:34:37.191Z" },
 ]
 
 [[package]]
@@ -126,6 +248,15 @@ wheels = [
 ]
 
 [[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
 name = "psycopg"
 version = "3.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -181,6 +312,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/2c/a4981bf42cf30ebba0424971d7ce70a222ae9b82594c42fc3f2105d7b525/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d", size = 3944542, upload-time = "2026-02-18T16:52:04.266Z" },
     { url = "https://files.pythonhosted.org/packages/60/e9/b7c29b56aa0b85a4e0c4d89db691c1ceef08f46a356369144430c155a2f5/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856", size = 4254339, upload-time = "2026-02-18T16:52:10.444Z" },
     { url = "https://files.pythonhosted.org/packages/98/5a/291d89f44d3820fffb7a04ebc8f3ef5dda4f542f44a5daea0c55a84abf45/psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383", size = 3652796, upload-time = "2026-02-18T16:52:14.02Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -335,8 +475,10 @@ name = "thedistance-appview"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "authlib" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "itsdangerous" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -351,8 +493,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "authlib", specifier = ">=1.3" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.28" },
+    { name = "itsdangerous", specifier = ">=2.1" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
     { name = "pydantic-settings", specifier = ">=2.6" },
     { name = "python-dotenv", specifier = ">=1.0" },

--- a/web/app.js
+++ b/web/app.js
@@ -1,116 +1,12 @@
-const API_BASE = "http://localhost:8000";
-
-function metersToMiles(m) {
-  return (parseFloat(m) / 1609.344).toFixed(1);
-}
-
-function msToMph(ms) {
-  return (parseFloat(ms) * 2.23694).toFixed(1);
-}
-
-function metersToFeet(m) {
-  return Math.round(parseFloat(m) * 3.28084);
-}
-
-function formatDuration(seconds) {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = seconds % 60;
-  if (h > 0) {
-    return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
-  }
-  return `${m}:${String(s).padStart(2, "0")}`;
-}
-
-function formatDate(iso) {
-  return new Date(iso).toLocaleDateString("en-US", {
-    weekday: "short",
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-}
-
-function renderActivity(activity) {
-  const stats = [];
-
-  stats.push({ label: "Distance", value: `${metersToMiles(activity.distance)} mi` });
-  stats.push({ label: "Moving Time", value: formatDuration(activity.moving_time) });
-  stats.push({ label: "Elapsed Time", value: formatDuration(activity.elapsed_time) });
-
-  if (activity.elevation_gain) {
-    stats.push({ label: "Elevation", value: `${metersToFeet(activity.elevation_gain)} ft` });
-  }
-  if (activity.avg_speed) {
-    stats.push({ label: "Avg Speed", value: `${msToMph(activity.avg_speed)} mph` });
-  }
-  if (activity.avg_heart_rate) {
-    const hr = activity.max_heart_rate
-      ? `${activity.avg_heart_rate} / ${activity.max_heart_rate}`
-      : `${activity.avg_heart_rate}`;
-    stats.push({ label: "Heart Rate", value: `${hr} bpm` });
-  }
-  if (activity.avg_power) {
-    stats.push({ label: "Avg Power", value: `${activity.avg_power} W` });
-  }
-
-  const statsHtml = stats
-    .map(
-      (s) => `<div class="stat">
-        <div class="stat-label">${s.label}</div>
-        <div class="stat-value">${s.value}</div>
-      </div>`
-    )
-    .join("");
-
-  const device = activity.device
-    ? `<div class="activity-device">${activity.device}</div>`
-    : "";
-
-  return `<article class="activity">
-    <div class="activity-header">
-      <div class="activity-title">${activity.title || "Untitled Ride"}</div>
-      <div class="activity-did">${activity.did}</div>
-    </div>
-    <div class="activity-date">${formatDate(activity.started_at)}</div>
-    <div class="activity-stats">${statsHtml}</div>
-    ${device}
-  </article>`;
-}
-
-async function loadActivities(did) {
-  const container = document.getElementById("activities");
-  container.innerHTML = '<p class="loading">Loading activities\u2026</p>';
-
-  let url = `${API_BASE}/api/activities`;
-  if (did) {
-    url = `${API_BASE}/api/activities/${encodeURIComponent(did)}`;
-  }
-
-  try {
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const activities = await res.json();
-
-    if (activities.length === 0) {
-      container.innerHTML = "<p>No activities found.</p>";
-      return;
-    }
-
-    container.innerHTML = activities.map(renderActivity).join("");
-  } catch (err) {
-    container.innerHTML = `<p class="error">${err.message}</p>`;
-  }
-}
-
 const form = document.getElementById("lookup");
 const input = document.getElementById("handle");
+const container = document.getElementById("activities");
 
 form.addEventListener("submit", (e) => {
   e.preventDefault();
   const did = input.value.trim();
-  loadActivities(did || null);
+  loadActivities(container, did || null, false);
 });
 
-// Load global feed on page load
-loadActivities();
+checkAuth();
+loadActivities(container, null, false);

--- a/web/index.html
+++ b/web/index.html
@@ -8,7 +8,10 @@
 </head>
 <body>
   <header>
-    <h1>The Distance</h1>
+    <div class="header-top">
+      <h1>The Distance</h1>
+      <div id="auth"></div>
+    </div>
     <p>Activities on the AT Protocol</p>
   </header>
   <main>
@@ -19,6 +22,7 @@
     <div id="profile"></div>
     <div id="activities"></div>
   </main>
+  <script src="/shared.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "web",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "live-server --port=8001 --host=127.0.0.1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "live-server": "1.2.2"
+  }
+}

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -1,0 +1,1420 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      live-server:
+        specifier: 1.2.2
+        version: 1.2.2
+
+packages:
+
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
+  anymatch@2.0.0:
+    resolution: {integrity: sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==}
+
+  apache-crypt@1.2.6:
+    resolution: {integrity: sha512-072WetlM4blL8PREJVeY+WHiUh1R5VNt2HfceGS8aKqttPHcmqE5pkKuXPz/ULmJOFkc8Hw3kfKl6vy7Qka6DA==}
+    engines: {node: '>=8'}
+
+  apache-md5@1.1.8:
+    resolution: {integrity: sha512-FCAJojipPn0bXjuEpjOOOMN8FZDkxfWWp4JGN9mifU2IhxvKyXZYqpzPHdnTSUpmPDy+tsslB6Z1g+Vg6nVbYA==}
+    engines: {node: '>=8'}
+
+  arr-diff@4.0.0:
+    resolution: {integrity: sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==}
+    engines: {node: '>=0.10.0'}
+
+  arr-flatten@1.1.0:
+    resolution: {integrity: sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==}
+    engines: {node: '>=0.10.0'}
+
+  arr-union@3.1.0:
+    resolution: {integrity: sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==}
+    engines: {node: '>=0.10.0'}
+
+  array-unique@0.3.2:
+    resolution: {integrity: sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==}
+    engines: {node: '>=0.10.0'}
+
+  assign-symbols@1.0.0:
+    resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
+    engines: {node: '>=0.10.0'}
+
+  async-each@1.0.6:
+    resolution: {integrity: sha512-c646jH1avxr+aVpndVMeAfYw7wAa6idufrlN3LPA4PmKS0QEGp6PIC9nwz0WQkkvBGAMEki3pFdtxaF39J9vvg==}
+
+  atob@2.1.2:
+    resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
+    engines: {node: '>= 4.5.0'}
+    hasBin: true
+
+  base@0.11.2:
+    resolution: {integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==}
+    engines: {node: '>=0.10.0'}
+
+  basic-auth@2.0.1:
+    resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
+    engines: {node: '>= 0.8'}
+
+  batch@0.6.1:
+    resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
+
+  bcryptjs@2.4.3:
+    resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
+
+  binary-extensions@1.13.1:
+    resolution: {integrity: sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==}
+    engines: {node: '>=0.10.0'}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  braces@2.3.2:
+    resolution: {integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==}
+    engines: {node: '>=0.10.0'}
+
+  cache-base@1.0.1:
+    resolution: {integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==}
+    engines: {node: '>=0.10.0'}
+
+  chokidar@2.1.8:
+    resolution: {integrity: sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==}
+
+  class-utils@0.3.6:
+    resolution: {integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==}
+    engines: {node: '>=0.10.0'}
+
+  collection-visit@1.0.0:
+    resolution: {integrity: sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==}
+    engines: {node: '>=0.10.0'}
+
+  colors@1.4.0:
+    resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
+    engines: {node: '>=0.1.90'}
+
+  component-emitter@1.3.1:
+    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+
+  connect@3.7.0:
+    resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
+    engines: {node: '>= 0.10.0'}
+
+  copy-descriptor@0.1.1:
+    resolution: {integrity: sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==}
+    engines: {node: '>=0.10.0'}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decode-uri-component@0.2.2:
+    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
+    engines: {node: '>=0.10'}
+
+  define-property@0.2.5:
+    resolution: {integrity: sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==}
+    engines: {node: '>=0.10.0'}
+
+  define-property@1.0.0:
+    resolution: {integrity: sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==}
+    engines: {node: '>=0.10.0'}
+
+  define-property@2.0.2:
+    resolution: {integrity: sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==}
+    engines: {node: '>=0.10.0'}
+
+  depd@1.1.2:
+    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
+    engines: {node: '>= 0.6'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  duplexer@0.1.2:
+    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  event-stream@3.3.4:
+    resolution: {integrity: sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==}
+
+  expand-brackets@2.1.4:
+    resolution: {integrity: sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==}
+    engines: {node: '>=0.10.0'}
+
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
+  extend-shallow@3.0.2:
+    resolution: {integrity: sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==}
+    engines: {node: '>=0.10.0'}
+
+  extglob@2.0.4:
+    resolution: {integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==}
+    engines: {node: '>=0.10.0'}
+
+  faye-websocket@0.11.4:
+    resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
+    engines: {node: '>=0.8.0'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  fill-range@4.0.0:
+    resolution: {integrity: sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==}
+    engines: {node: '>=0.10.0'}
+
+  finalhandler@1.1.2:
+    resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
+    engines: {node: '>= 0.8'}
+
+  for-in@1.0.2:
+    resolution: {integrity: sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==}
+    engines: {node: '>=0.10.0'}
+
+  fragment-cache@0.2.1:
+    resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==}
+    engines: {node: '>=0.10.0'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  from@0.1.7:
+    resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
+
+  fsevents@1.2.13:
+    resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
+    engines: {node: '>= 4.0'}
+    os: [darwin]
+    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-value@2.0.6:
+    resolution: {integrity: sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==}
+    engines: {node: '>=0.10.0'}
+
+  glob-parent@3.1.0:
+    resolution: {integrity: sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  has-value@0.3.1:
+    resolution: {integrity: sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==}
+    engines: {node: '>=0.10.0'}
+
+  has-value@1.0.0:
+    resolution: {integrity: sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==}
+    engines: {node: '>=0.10.0'}
+
+  has-values@0.1.4:
+    resolution: {integrity: sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==}
+    engines: {node: '>=0.10.0'}
+
+  has-values@1.0.0:
+    resolution: {integrity: sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==}
+    engines: {node: '>=0.10.0'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  http-auth@3.1.3:
+    resolution: {integrity: sha512-Jbx0+ejo2IOx+cRUYAGS1z6RGc6JfYUNkysZM4u4Sfk1uLlGv814F7/PIjQQAuThLdAWxb74JMGd5J8zex1VQg==}
+    engines: {node: '>=4.6.1'}
+
+  http-errors@1.8.1:
+    resolution: {integrity: sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==}
+    engines: {node: '>= 0.6'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  http-parser-js@0.5.10:
+    resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-accessor-descriptor@1.0.1:
+    resolution: {integrity: sha512-YBUanLI8Yoihw923YeFUS5fs0fF2f5TSFTNiYAAzhhDscDa3lEqYuz1pDOEP5KvX94I9ey3vsqjJcLVFVU+3QA==}
+    engines: {node: '>= 0.10'}
+
+  is-binary-path@1.0.1:
+    resolution: {integrity: sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==}
+    engines: {node: '>=0.10.0'}
+
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+
+  is-data-descriptor@1.0.1:
+    resolution: {integrity: sha512-bc4NlCDiCr28U4aEsQ3Qs2491gVq4V8G7MQyws968ImqjKuYtTJXrl7Vq7jsN7Ly/C3xj5KWFrY7sHNeDkAzXw==}
+    engines: {node: '>= 0.4'}
+
+  is-descriptor@0.1.7:
+    resolution: {integrity: sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg==}
+    engines: {node: '>= 0.4'}
+
+  is-descriptor@1.0.3:
+    resolution: {integrity: sha512-JCNNGbwWZEVaSPtS45mdtrneRWJFp07LLmykxeFV5F6oBvNF8vHSfJuJgoT472pSfk+Mf8VnlrspaFBHWM8JAw==}
+    engines: {node: '>= 0.4'}
+
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
+  is-extendable@1.0.1:
+    resolution: {integrity: sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==}
+    engines: {node: '>=0.10.0'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@3.1.0:
+    resolution: {integrity: sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@3.0.0:
+    resolution: {integrity: sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==}
+    engines: {node: '>=0.10.0'}
+
+  is-plain-object@2.0.4:
+    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
+
+  is-windows@1.0.2:
+    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
+    engines: {node: '>=0.10.0'}
+
+  is-wsl@1.1.0:
+    resolution: {integrity: sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==}
+    engines: {node: '>=4'}
+
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
+  isobject@2.1.0:
+    resolution: {integrity: sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==}
+    engines: {node: '>=0.10.0'}
+
+  isobject@3.0.1:
+    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
+    engines: {node: '>=0.10.0'}
+
+  kind-of@3.2.2:
+    resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
+    engines: {node: '>=0.10.0'}
+
+  kind-of@4.0.0:
+    resolution: {integrity: sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==}
+    engines: {node: '>=0.10.0'}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
+
+  live-server@1.2.2:
+    resolution: {integrity: sha512-t28HXLjITRGoMSrCOv4eZ88viHaBVIjKjdI5PO92Vxlu+twbk6aE0t7dVIaz6ZWkjPilYFV6OSdMYl9ybN2B4w==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
+  map-cache@0.2.2:
+    resolution: {integrity: sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==}
+    engines: {node: '>=0.10.0'}
+
+  map-stream@0.1.0:
+    resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
+
+  map-visit@1.0.0:
+    resolution: {integrity: sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==}
+    engines: {node: '>=0.10.0'}
+
+  micromatch@3.1.10:
+    resolution: {integrity: sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==}
+    engines: {node: '>=0.10.0'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  mixin-deep@1.3.2:
+    resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==}
+    engines: {node: '>=0.10.0'}
+
+  morgan@1.10.1:
+    resolution: {integrity: sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==}
+    engines: {node: '>= 0.8.0'}
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nan@2.26.2:
+    resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
+
+  nanomatch@1.2.13:
+    resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==}
+    engines: {node: '>=0.10.0'}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  normalize-path@2.1.1:
+    resolution: {integrity: sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==}
+    engines: {node: '>=0.10.0'}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-copy@0.1.0:
+    resolution: {integrity: sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==}
+    engines: {node: '>=0.10.0'}
+
+  object-visit@1.0.1:
+    resolution: {integrity: sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==}
+    engines: {node: '>=0.10.0'}
+
+  object.pick@1.3.0:
+    resolution: {integrity: sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==}
+    engines: {node: '>=0.10.0'}
+
+  on-finished@2.3.0:
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    engines: {node: '>= 0.8'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  on-headers@1.1.0:
+    resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
+    engines: {node: '>= 0.8'}
+
+  opn@6.0.0:
+    resolution: {integrity: sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==}
+    engines: {node: '>=8'}
+    deprecated: The package has been renamed to `open`
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  pascalcase@0.1.1:
+    resolution: {integrity: sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==}
+    engines: {node: '>=0.10.0'}
+
+  path-dirname@1.0.2:
+    resolution: {integrity: sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  pause-stream@0.0.11:
+    resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
+
+  posix-character-classes@0.1.1:
+    resolution: {integrity: sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==}
+    engines: {node: '>=0.10.0'}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  proxy-middleware@0.15.0:
+    resolution: {integrity: sha512-EGCG8SeoIRVMhsqHQUdDigB2i7qU7fCsWASwn54+nPutYO8n4q6EiwMzyfWlC+dzRFExP+kvcnDFdBDHoZBU7Q==}
+    engines: {node: '>=0.8.0'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readdirp@2.2.1:
+    resolution: {integrity: sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==}
+    engines: {node: '>=0.10'}
+
+  regex-not@1.0.2:
+    resolution: {integrity: sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==}
+    engines: {node: '>=0.10.0'}
+
+  remove-trailing-separator@1.1.0:
+    resolution: {integrity: sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==}
+
+  repeat-element@1.1.4:
+    resolution: {integrity: sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==}
+    engines: {node: '>=0.10.0'}
+
+  repeat-string@1.6.1:
+    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
+    engines: {node: '>=0.10'}
+
+  resolve-url@0.2.1:
+    resolution: {integrity: sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==}
+    deprecated: https://github.com/lydell/resolve-url#deprecated
+
+  ret@0.1.15:
+    resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==}
+    engines: {node: '>=0.12'}
+
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-regex@1.1.0:
+    resolution: {integrity: sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==}
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-index@1.9.2:
+    resolution: {integrity: sha512-KDj11HScOaLmrPxl70KYNW1PksP4Nb/CLL2yvC+Qd2kHMPEEpfc4Re2e4FOay+bC/+XQl/7zAcWON3JVo5v3KQ==}
+    engines: {node: '>= 0.8.0'}
+
+  set-value@2.0.1:
+    resolution: {integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==}
+    engines: {node: '>=0.10.0'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  snapdragon-node@2.1.1:
+    resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==}
+    engines: {node: '>=0.10.0'}
+
+  snapdragon-util@3.0.1:
+    resolution: {integrity: sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==}
+    engines: {node: '>=0.10.0'}
+
+  snapdragon@0.8.2:
+    resolution: {integrity: sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-resolve@0.5.3:
+    resolution: {integrity: sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==}
+    deprecated: See https://github.com/lydell/source-map-resolve#deprecated
+
+  source-map-url@0.4.1:
+    resolution: {integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==}
+    deprecated: See https://github.com/lydell/source-map-url#deprecated
+
+  source-map@0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
+
+  split-string@3.1.0:
+    resolution: {integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==}
+    engines: {node: '>=0.10.0'}
+
+  split@0.3.3:
+    resolution: {integrity: sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==}
+
+  static-extend@0.1.2:
+    resolution: {integrity: sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==}
+    engines: {node: '>=0.10.0'}
+
+  statuses@1.5.0:
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
+    engines: {node: '>= 0.6'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  stream-combiner@0.0.4:
+    resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
+  to-object-path@0.3.0:
+    resolution: {integrity: sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==}
+    engines: {node: '>=0.10.0'}
+
+  to-regex-range@2.1.1:
+    resolution: {integrity: sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==}
+    engines: {node: '>=0.10.0'}
+
+  to-regex@3.0.2:
+    resolution: {integrity: sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==}
+    engines: {node: '>=0.10.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  union-value@1.0.1:
+    resolution: {integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==}
+    engines: {node: '>=0.10.0'}
+
+  unix-crypt-td-js@1.1.4:
+    resolution: {integrity: sha512-8rMeVYWSIyccIJscb9NdCfZKSRBKYTeVnwmiRYT2ulE3qd1RaDQ0xQDP+rI3ccIWbhu/zuo5cgN8z73belNZgw==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  unset-value@1.0.0:
+    resolution: {integrity: sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==}
+    engines: {node: '>=0.10.0'}
+
+  upath@1.2.0:
+    resolution: {integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==}
+    engines: {node: '>=4'}
+
+  urix@0.1.0:
+    resolution: {integrity: sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==}
+    deprecated: Please see https://github.com/lydell/urix#deprecated
+
+  use@3.1.1:
+    resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==}
+    engines: {node: '>=0.10.0'}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
+  uuid@3.4.0:
+    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
+    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  websocket-driver@0.7.4:
+    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+    engines: {node: '>=0.8.0'}
+
+  websocket-extensions@0.1.4:
+    resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
+    engines: {node: '>=0.8.0'}
+
+snapshots:
+
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
+  anymatch@2.0.0:
+    dependencies:
+      micromatch: 3.1.10
+      normalize-path: 2.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  apache-crypt@1.2.6:
+    dependencies:
+      unix-crypt-td-js: 1.1.4
+
+  apache-md5@1.1.8: {}
+
+  arr-diff@4.0.0: {}
+
+  arr-flatten@1.1.0: {}
+
+  arr-union@3.1.0: {}
+
+  array-unique@0.3.2: {}
+
+  assign-symbols@1.0.0: {}
+
+  async-each@1.0.6: {}
+
+  atob@2.1.2: {}
+
+  base@0.11.2:
+    dependencies:
+      cache-base: 1.0.1
+      class-utils: 0.3.6
+      component-emitter: 1.3.1
+      define-property: 1.0.0
+      isobject: 3.0.1
+      mixin-deep: 1.3.2
+      pascalcase: 0.1.1
+
+  basic-auth@2.0.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  batch@0.6.1: {}
+
+  bcryptjs@2.4.3: {}
+
+  binary-extensions@1.13.1: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+    optional: true
+
+  braces@2.3.2:
+    dependencies:
+      arr-flatten: 1.1.0
+      array-unique: 0.3.2
+      extend-shallow: 2.0.1
+      fill-range: 4.0.0
+      isobject: 3.0.1
+      repeat-element: 1.1.4
+      snapdragon: 0.8.2
+      snapdragon-node: 2.1.1
+      split-string: 3.1.0
+      to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  cache-base@1.0.1:
+    dependencies:
+      collection-visit: 1.0.0
+      component-emitter: 1.3.1
+      get-value: 2.0.6
+      has-value: 1.0.0
+      isobject: 3.0.1
+      set-value: 2.0.1
+      to-object-path: 0.3.0
+      union-value: 1.0.1
+      unset-value: 1.0.0
+
+  chokidar@2.1.8:
+    dependencies:
+      anymatch: 2.0.0
+      async-each: 1.0.6
+      braces: 2.3.2
+      glob-parent: 3.1.0
+      inherits: 2.0.4
+      is-binary-path: 1.0.1
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      path-is-absolute: 1.0.1
+      readdirp: 2.2.1
+      upath: 1.2.0
+    optionalDependencies:
+      fsevents: 1.2.13
+    transitivePeerDependencies:
+      - supports-color
+
+  class-utils@0.3.6:
+    dependencies:
+      arr-union: 3.1.0
+      define-property: 0.2.5
+      isobject: 3.0.1
+      static-extend: 0.1.2
+
+  collection-visit@1.0.0:
+    dependencies:
+      map-visit: 1.0.0
+      object-visit: 1.0.1
+
+  colors@1.4.0: {}
+
+  component-emitter@1.3.1: {}
+
+  connect@3.7.0:
+    dependencies:
+      debug: 2.6.9
+      finalhandler: 1.1.2
+      parseurl: 1.3.3
+      utils-merge: 1.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  copy-descriptor@0.1.1: {}
+
+  core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decode-uri-component@0.2.2: {}
+
+  define-property@0.2.5:
+    dependencies:
+      is-descriptor: 0.1.7
+
+  define-property@1.0.0:
+    dependencies:
+      is-descriptor: 1.0.3
+
+  define-property@2.0.2:
+    dependencies:
+      is-descriptor: 1.0.3
+      isobject: 3.0.1
+
+  depd@1.1.2: {}
+
+  depd@2.0.0: {}
+
+  duplexer@0.1.2: {}
+
+  ee-first@1.1.1: {}
+
+  encodeurl@1.0.2: {}
+
+  encodeurl@2.0.0: {}
+
+  escape-html@1.0.3: {}
+
+  etag@1.8.1: {}
+
+  event-stream@3.3.4:
+    dependencies:
+      duplexer: 0.1.2
+      from: 0.1.7
+      map-stream: 0.1.0
+      pause-stream: 0.0.11
+      split: 0.3.3
+      stream-combiner: 0.0.4
+      through: 2.3.8
+
+  expand-brackets@2.1.4:
+    dependencies:
+      debug: 2.6.9
+      define-property: 0.2.5
+      extend-shallow: 2.0.1
+      posix-character-classes: 0.1.1
+      regex-not: 1.0.2
+      snapdragon: 0.8.2
+      to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
+  extend-shallow@3.0.2:
+    dependencies:
+      assign-symbols: 1.0.0
+      is-extendable: 1.0.1
+
+  extglob@2.0.4:
+    dependencies:
+      array-unique: 0.3.2
+      define-property: 1.0.0
+      expand-brackets: 2.1.4
+      extend-shallow: 2.0.1
+      fragment-cache: 0.2.1
+      regex-not: 1.0.2
+      snapdragon: 0.8.2
+      to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  faye-websocket@0.11.4:
+    dependencies:
+      websocket-driver: 0.7.4
+
+  file-uri-to-path@1.0.0:
+    optional: true
+
+  fill-range@4.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      is-number: 3.0.0
+      repeat-string: 1.6.1
+      to-regex-range: 2.1.1
+
+  finalhandler@1.1.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      on-finished: 2.3.0
+      parseurl: 1.3.3
+      statuses: 1.5.0
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  for-in@1.0.2: {}
+
+  fragment-cache@0.2.1:
+    dependencies:
+      map-cache: 0.2.2
+
+  fresh@2.0.0: {}
+
+  from@0.1.7: {}
+
+  fsevents@1.2.13:
+    dependencies:
+      bindings: 1.5.0
+      nan: 2.26.2
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-value@2.0.6: {}
+
+  glob-parent@3.1.0:
+    dependencies:
+      is-glob: 3.1.0
+      path-dirname: 1.0.2
+
+  graceful-fs@4.2.11: {}
+
+  has-value@0.3.1:
+    dependencies:
+      get-value: 2.0.6
+      has-values: 0.1.4
+      isobject: 2.1.0
+
+  has-value@1.0.0:
+    dependencies:
+      get-value: 2.0.6
+      has-values: 1.0.0
+      isobject: 3.0.1
+
+  has-values@0.1.4: {}
+
+  has-values@1.0.0:
+    dependencies:
+      is-number: 3.0.0
+      kind-of: 4.0.0
+
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  http-auth@3.1.3:
+    dependencies:
+      apache-crypt: 1.2.6
+      apache-md5: 1.1.8
+      bcryptjs: 2.4.3
+      uuid: 3.4.0
+
+  http-errors@1.8.1:
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 1.5.0
+      toidentifier: 1.0.1
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  http-parser-js@0.5.10: {}
+
+  inherits@2.0.4: {}
+
+  is-accessor-descriptor@1.0.1:
+    dependencies:
+      hasown: 2.0.2
+
+  is-binary-path@1.0.1:
+    dependencies:
+      binary-extensions: 1.13.1
+
+  is-buffer@1.1.6: {}
+
+  is-data-descriptor@1.0.1:
+    dependencies:
+      hasown: 2.0.2
+
+  is-descriptor@0.1.7:
+    dependencies:
+      is-accessor-descriptor: 1.0.1
+      is-data-descriptor: 1.0.1
+
+  is-descriptor@1.0.3:
+    dependencies:
+      is-accessor-descriptor: 1.0.1
+      is-data-descriptor: 1.0.1
+
+  is-extendable@0.1.1: {}
+
+  is-extendable@1.0.1:
+    dependencies:
+      is-plain-object: 2.0.4
+
+  is-extglob@2.1.1: {}
+
+  is-glob@3.1.0:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@3.0.0:
+    dependencies:
+      kind-of: 3.2.2
+
+  is-plain-object@2.0.4:
+    dependencies:
+      isobject: 3.0.1
+
+  is-windows@1.0.2: {}
+
+  is-wsl@1.1.0: {}
+
+  isarray@1.0.0: {}
+
+  isobject@2.1.0:
+    dependencies:
+      isarray: 1.0.0
+
+  isobject@3.0.1: {}
+
+  kind-of@3.2.2:
+    dependencies:
+      is-buffer: 1.1.6
+
+  kind-of@4.0.0:
+    dependencies:
+      is-buffer: 1.1.6
+
+  kind-of@6.0.3: {}
+
+  live-server@1.2.2:
+    dependencies:
+      chokidar: 2.1.8
+      colors: 1.4.0
+      connect: 3.7.0
+      cors: 2.8.6
+      event-stream: 3.3.4
+      faye-websocket: 0.11.4
+      http-auth: 3.1.3
+      morgan: 1.10.1
+      object-assign: 4.1.1
+      opn: 6.0.0
+      proxy-middleware: 0.15.0
+      send: 1.2.1
+      serve-index: 1.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  map-cache@0.2.2: {}
+
+  map-stream@0.1.0: {}
+
+  map-visit@1.0.0:
+    dependencies:
+      object-visit: 1.0.1
+
+  micromatch@3.1.10:
+    dependencies:
+      arr-diff: 4.0.0
+      array-unique: 0.3.2
+      braces: 2.3.2
+      define-property: 2.0.2
+      extend-shallow: 3.0.2
+      extglob: 2.0.4
+      fragment-cache: 0.2.1
+      kind-of: 6.0.3
+      nanomatch: 1.2.13
+      object.pick: 1.3.0
+      regex-not: 1.0.2
+      snapdragon: 0.8.2
+      to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  mixin-deep@1.3.2:
+    dependencies:
+      for-in: 1.0.2
+      is-extendable: 1.0.1
+
+  morgan@1.10.1:
+    dependencies:
+      basic-auth: 2.0.1
+      debug: 2.6.9
+      depd: 2.0.0
+      on-finished: 2.3.0
+      on-headers: 1.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  ms@2.0.0: {}
+
+  ms@2.1.3: {}
+
+  nan@2.26.2:
+    optional: true
+
+  nanomatch@1.2.13:
+    dependencies:
+      arr-diff: 4.0.0
+      array-unique: 0.3.2
+      define-property: 2.0.2
+      extend-shallow: 3.0.2
+      fragment-cache: 0.2.1
+      is-windows: 1.0.2
+      kind-of: 6.0.3
+      object.pick: 1.3.0
+      regex-not: 1.0.2
+      snapdragon: 0.8.2
+      to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  negotiator@0.6.3: {}
+
+  normalize-path@2.1.1:
+    dependencies:
+      remove-trailing-separator: 1.1.0
+
+  normalize-path@3.0.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-copy@0.1.0:
+    dependencies:
+      copy-descriptor: 0.1.1
+      define-property: 0.2.5
+      kind-of: 3.2.2
+
+  object-visit@1.0.1:
+    dependencies:
+      isobject: 3.0.1
+
+  object.pick@1.3.0:
+    dependencies:
+      isobject: 3.0.1
+
+  on-finished@2.3.0:
+    dependencies:
+      ee-first: 1.1.1
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  on-headers@1.1.0: {}
+
+  opn@6.0.0:
+    dependencies:
+      is-wsl: 1.1.0
+
+  parseurl@1.3.3: {}
+
+  pascalcase@0.1.1: {}
+
+  path-dirname@1.0.2: {}
+
+  path-is-absolute@1.0.1: {}
+
+  pause-stream@0.0.11:
+    dependencies:
+      through: 2.3.8
+
+  posix-character-classes@0.1.1: {}
+
+  process-nextick-args@2.0.1: {}
+
+  proxy-middleware@0.15.0: {}
+
+  range-parser@1.2.1: {}
+
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readdirp@2.2.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      micromatch: 3.1.10
+      readable-stream: 2.3.8
+    transitivePeerDependencies:
+      - supports-color
+
+  regex-not@1.0.2:
+    dependencies:
+      extend-shallow: 3.0.2
+      safe-regex: 1.1.0
+
+  remove-trailing-separator@1.1.0: {}
+
+  repeat-element@1.1.4: {}
+
+  repeat-string@1.6.1: {}
+
+  resolve-url@0.2.1: {}
+
+  ret@0.1.15: {}
+
+  safe-buffer@5.1.2: {}
+
+  safe-buffer@5.2.1: {}
+
+  safe-regex@1.1.0:
+    dependencies:
+      ret: 0.1.15
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-index@1.9.2:
+    dependencies:
+      accepts: 1.3.8
+      batch: 0.6.1
+      debug: 2.6.9
+      escape-html: 1.0.3
+      http-errors: 1.8.1
+      mime-types: 2.1.35
+      parseurl: 1.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  set-value@2.0.1:
+    dependencies:
+      extend-shallow: 2.0.1
+      is-extendable: 0.1.1
+      is-plain-object: 2.0.4
+      split-string: 3.1.0
+
+  setprototypeof@1.2.0: {}
+
+  snapdragon-node@2.1.1:
+    dependencies:
+      define-property: 1.0.0
+      isobject: 3.0.1
+      snapdragon-util: 3.0.1
+
+  snapdragon-util@3.0.1:
+    dependencies:
+      kind-of: 3.2.2
+
+  snapdragon@0.8.2:
+    dependencies:
+      base: 0.11.2
+      debug: 2.6.9
+      define-property: 0.2.5
+      extend-shallow: 2.0.1
+      map-cache: 0.2.2
+      source-map: 0.5.7
+      source-map-resolve: 0.5.3
+      use: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  source-map-resolve@0.5.3:
+    dependencies:
+      atob: 2.1.2
+      decode-uri-component: 0.2.2
+      resolve-url: 0.2.1
+      source-map-url: 0.4.1
+      urix: 0.1.0
+
+  source-map-url@0.4.1: {}
+
+  source-map@0.5.7: {}
+
+  split-string@3.1.0:
+    dependencies:
+      extend-shallow: 3.0.2
+
+  split@0.3.3:
+    dependencies:
+      through: 2.3.8
+
+  static-extend@0.1.2:
+    dependencies:
+      define-property: 0.2.5
+      object-copy: 0.1.0
+
+  statuses@1.5.0: {}
+
+  statuses@2.0.2: {}
+
+  stream-combiner@0.0.4:
+    dependencies:
+      duplexer: 0.1.2
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  through@2.3.8: {}
+
+  to-object-path@0.3.0:
+    dependencies:
+      kind-of: 3.2.2
+
+  to-regex-range@2.1.1:
+    dependencies:
+      is-number: 3.0.0
+      repeat-string: 1.6.1
+
+  to-regex@3.0.2:
+    dependencies:
+      define-property: 2.0.2
+      extend-shallow: 3.0.2
+      regex-not: 1.0.2
+      safe-regex: 1.1.0
+
+  toidentifier@1.0.1: {}
+
+  union-value@1.0.1:
+    dependencies:
+      arr-union: 3.1.0
+      get-value: 2.0.6
+      is-extendable: 0.1.1
+      set-value: 2.0.1
+
+  unix-crypt-td-js@1.1.4: {}
+
+  unpipe@1.0.0: {}
+
+  unset-value@1.0.0:
+    dependencies:
+      has-value: 0.3.1
+      isobject: 3.0.1
+
+  upath@1.2.0: {}
+
+  urix@0.1.0: {}
+
+  use@3.1.1: {}
+
+  util-deprecate@1.0.2: {}
+
+  utils-merge@1.0.1: {}
+
+  uuid@3.4.0: {}
+
+  vary@1.1.2: {}
+
+  websocket-driver@0.7.4:
+    dependencies:
+      http-parser-js: 0.5.10
+      safe-buffer: 5.2.1
+      websocket-extensions: 0.1.4
+
+  websocket-extensions@0.1.4: {}

--- a/web/profile/index.html
+++ b/web/profile/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Profile - The Distance</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <header>
+    <div class="header-top">
+      <h1><a href="/">The Distance</a></h1>
+      <div id="auth"></div>
+    </div>
+  </header>
+  <main>
+    <h2 id="profile-handle"></h2>
+    <div id="activities"></div>
+  </main>
+  <script src="/shared.js"></script>
+  <script src="profile.js"></script>
+</body>
+</html>

--- a/web/profile/profile.js
+++ b/web/profile/profile.js
@@ -1,0 +1,34 @@
+const params = new URLSearchParams(window.location.search);
+const handle = params.get("handle");
+
+async function init() {
+  await checkAuth();
+
+  if (!handle) {
+    document.getElementById("activities").innerHTML =
+      '<p class="error">No handle provided.</p>';
+    return;
+  }
+
+  document.getElementById("profile-handle").textContent = handle;
+
+  let did;
+  try {
+    const res = await fetch(
+      `${API_BASE}/api/resolve/${encodeURIComponent(handle)}`,
+      fetchOpts
+    );
+    if (!res.ok) throw new Error("Could not resolve handle");
+    const data = await res.json();
+    did = data.did;
+  } catch (err) {
+    document.getElementById("activities").innerHTML =
+      `<p class="error">${err.message}</p>`;
+    return;
+  }
+
+  const isOwner = currentUser && currentUser.did === did;
+  loadActivities(document.getElementById("activities"), did, isOwner);
+}
+
+init();

--- a/web/shared.js
+++ b/web/shared.js
@@ -1,0 +1,254 @@
+const API_BASE = "http://127.0.0.1:8000";
+
+const fetchOpts = { credentials: "include" };
+
+let currentUser = null;
+
+function metersToMiles(m) {
+  return (parseFloat(m) / 1609.344).toFixed(1);
+}
+
+function msToMph(ms) {
+  return (parseFloat(ms) * 2.23694).toFixed(1);
+}
+
+function metersToFeet(m) {
+  return Math.round(parseFloat(m) * 3.28084);
+}
+
+function formatDuration(seconds) {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  if (h > 0) {
+    return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+  }
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+function formatDate(iso) {
+  return new Date(iso).toLocaleDateString("en-US", {
+    weekday: "short",
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function renderActivity(activity, showDelete) {
+  const stats = [];
+
+  stats.push({
+    label: "Distance",
+    value: `${metersToMiles(activity.distance)} mi`,
+  });
+  stats.push({
+    label: "Moving Time",
+    value: formatDuration(activity.moving_time),
+  });
+  stats.push({
+    label: "Elapsed Time",
+    value: formatDuration(activity.elapsed_time),
+  });
+
+  if (activity.elevation_gain) {
+    stats.push({
+      label: "Elevation",
+      value: `${metersToFeet(activity.elevation_gain)} ft`,
+    });
+  }
+  if (activity.avg_speed) {
+    stats.push({
+      label: "Avg Speed",
+      value: `${msToMph(activity.avg_speed)} mph`,
+    });
+  }
+  if (activity.avg_heart_rate) {
+    const hr = activity.max_heart_rate
+      ? `${activity.avg_heart_rate} / ${activity.max_heart_rate}`
+      : `${activity.avg_heart_rate}`;
+    stats.push({ label: "Heart Rate", value: `${hr} bpm` });
+  }
+  if (activity.avg_power) {
+    stats.push({ label: "Avg Power", value: `${activity.avg_power} W` });
+  }
+
+  const statsHtml = stats
+    .map(
+      (s) => `<div class="stat">
+        <div class="stat-label">${s.label}</div>
+        <div class="stat-value">${s.value}</div>
+      </div>`
+    )
+    .join("");
+
+  const device = activity.device
+    ? `<div class="activity-device">${activity.device}</div>`
+    : "";
+
+  const deleteBtn = showDelete
+    ? `<form class="delete-form" data-did="${activity.did}" data-rkey="${activity.rkey}">
+        <button type="submit" class="delete-btn">Delete</button>
+      </form>`
+    : "";
+
+  return `<article class="activity" id="activity-${activity.rkey}">
+    <div class="activity-header">
+      <div class="activity-title">${activity.title || "Untitled Ride"}</div>
+      <div class="activity-did">${activity.did}</div>
+    </div>
+    <div class="activity-date">${formatDate(activity.started_at)}</div>
+    <div class="activity-stats">${statsHtml}</div>
+    ${device}
+    ${deleteBtn}
+  </article>`;
+}
+
+async function loadActivities(container, did, showDelete) {
+  container.innerHTML = '<p class="loading">Loading activities\u2026</p>';
+
+  let url = `${API_BASE}/api/activities`;
+  if (did) {
+    url = `${API_BASE}/api/activities/${encodeURIComponent(did)}`;
+  }
+
+  try {
+    const res = await fetch(url, fetchOpts);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const activities = await res.json();
+
+    if (activities.length === 0) {
+      container.innerHTML = "<p>No activities found.</p>";
+      return;
+    }
+
+    container.innerHTML = activities
+      .map((a) => renderActivity(a, showDelete))
+      .join("");
+
+    if (showDelete) {
+      container.querySelectorAll(".delete-form").forEach((form) => {
+        form.addEventListener("submit", handleDelete);
+      });
+    }
+  } catch (err) {
+    container.innerHTML = `<p class="error">${err.message}</p>`;
+  }
+}
+
+async function handleDelete(e) {
+  e.preventDefault();
+  const form = e.target;
+  const did = form.dataset.did;
+  const rkey = form.dataset.rkey;
+  const btn = form.querySelector("button");
+
+  if (!confirm("Delete this activity?")) return;
+
+  btn.disabled = true;
+  btn.textContent = "Deleting\u2026";
+
+  try {
+    const res = await fetch(
+      `${API_BASE}/api/activities/${did}/${rkey}/delete`,
+      {
+        ...fetchOpts,
+        method: "POST",
+      }
+    );
+
+    if (!res.ok) {
+      const err = await res.json();
+      alert(err.error || "Delete failed");
+      btn.disabled = false;
+      btn.textContent = "Delete";
+      return;
+    }
+
+    const article = document.getElementById(`activity-${rkey}`);
+    if (article) article.remove();
+  } catch (err) {
+    alert("Delete failed: " + err.message);
+    btn.disabled = false;
+    btn.textContent = "Delete";
+  }
+}
+
+// --- Auth ---
+
+function renderLoginForm() {
+  return `<form id="login-form">
+    <input type="text" id="login-handle" placeholder="Handle (e.g. alice.bsky.social)" />
+    <button type="submit">Sign in</button>
+  </form>`;
+}
+
+function renderLoggedIn(handle) {
+  return `<a href="/profile/?handle=${handle}" class="auth-handle">${handle}</a>
+    <button id="logout-btn" type="button">Sign out</button>`;
+}
+
+async function checkAuth() {
+  const container = document.getElementById("auth");
+  try {
+    const res = await fetch(`${API_BASE}/oauth/me`, fetchOpts);
+    if (res.ok) {
+      currentUser = await res.json();
+      container.innerHTML = renderLoggedIn(currentUser.handle);
+      document.getElementById("logout-btn").addEventListener("click", logout);
+      return;
+    }
+  } catch (e) {
+    // Not logged in
+  }
+  currentUser = null;
+  container.innerHTML = renderLoginForm();
+  document.getElementById("login-form").addEventListener("submit", login);
+}
+
+async function login(e) {
+  e.preventDefault();
+  const input = document.getElementById("login-handle");
+  const username = input.value.trim();
+  if (!username) return;
+
+  const btn = e.target.querySelector("button");
+  btn.disabled = true;
+  btn.textContent = "Signing in\u2026";
+
+  try {
+    const res = await fetch(`${API_BASE}/oauth/login`, {
+      ...fetchOpts,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username }),
+    });
+
+    if (!res.ok) {
+      const err = await res.json();
+      alert(err.error || "Login failed");
+      return;
+    }
+
+    const data = await res.json();
+    window.location.href = data.redirect_url;
+  } catch (err) {
+    alert("Login failed: " + err.message);
+  } finally {
+    btn.disabled = false;
+    btn.textContent = "Sign in";
+  }
+}
+
+async function logout() {
+  try {
+    await fetch(`${API_BASE}/oauth/logout`, {
+      ...fetchOpts,
+      method: "POST",
+    });
+  } catch (e) {
+    // Continue with local cleanup even if server call fails
+  }
+  currentUser = null;
+  window.location.href = "/";
+}

--- a/web/style.css
+++ b/web/style.css
@@ -17,6 +17,12 @@ header {
   margin-bottom: 2rem;
 }
 
+.header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
 header h1 {
   font-size: 1.5rem;
 }
@@ -101,6 +107,50 @@ header p {
   margin-top: 0.75rem;
   font-size: 0.75rem;
   color: #999;
+}
+
+#auth {
+  font-size: 0.9rem;
+}
+
+#auth .auth-handle {
+  margin-right: 0.5rem;
+  font-weight: 600;
+}
+
+#login-form {
+  display: flex;
+  gap: 0.5rem;
+}
+
+#login-handle {
+  padding: 0.35rem 0.6rem;
+  font-size: 0.85rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+}
+
+#logout-btn {
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: none;
+  cursor: pointer;
+}
+
+.delete-form {
+  margin-top: 0.75rem;
+}
+
+.delete-btn {
+  padding: 0.3rem 0.6rem;
+  font-size: 0.8rem;
+  border: 1px solid #c00;
+  border-radius: 4px;
+  background: none;
+  color: #c00;
+  cursor: pointer;
 }
 
 #activities .loading {


### PR DESCRIPTION
## Summary

- Adds full AT Protocol OAuth 2.1 authentication using the BFF (Backend For Frontend) pattern, allowing users to sign in with their Bluesky account
- Adds identity resolution module (handle/DID/PDS lookup) shared between auth and backfill, replacing the inline resolution in backfill.py
- Adds profile page with authenticated record deletion -- users can delete their own `app.thedistance.activity` records via the PDS

## Details

**New modules:**
- `app/identity.py` -- handle/DID validation, resolution (HTTP well-known + XRPC fallback), bi-directional verification. Adapted from the [AT Protocol OAuth cookbook](https://github.com/bluesky-social/cookbook/tree/main/python-oauth-web-app)
- `app/oauth.py` -- DPoP proof generation, PAR, token exchange, refresh, revocation, authenticated PDS requests. Also adapted from the cookbook

**Auth flow:**
- `POST /oauth/login` -- accepts a handle, resolves identity, sends PAR, returns auth server redirect URL
- `GET /oauth/callback` -- exchanges auth code for tokens, saves session, redirects to frontend
- `POST /oauth/logout` -- revokes tokens, clears session
- `GET /oauth/me` -- returns current user info
- Session cookies (signed via `itsdangerous`) manage frontend-to-backend auth

**New endpoints:**
- `GET /api/resolve/{handle}` -- resolves a handle to a DID
- `POST /api/activities/{did}/{rkey}/delete` -- deletes a record from the user's PDS and local DB

**Frontend:**

Still extremely rough / just make it work. Not trying to add a bunch of JS and shit yet

- Auth UI in header (sign in form / signed-in handle with link to profile)
- Profile page at `/profile/?handle=` with delete buttons for the record owner
- Shared JS extracted for use across pages
- `live-server` added for frontend dev server

**Dependencies added:** `authlib`, `itsdangerous`

🤖 Generated with [Claude Code](https://claude.com/claude-code)