### PR TITLE
Adds profile storing and fetching

### DIFF
--- a/appview/app/db.py
+++ b/appview/app/db.py
@@ -79,6 +79,18 @@ def init_db():
         )
         conn.execute(
             """
+            CREATE TABLE IF NOT EXISTS profiles (
+                did TEXT PRIMARY KEY,
+                handle TEXT NOT NULL,
+                display_name TEXT,
+                description TEXT,
+                avatar_url TEXT,
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+        """
+        )
+        conn.execute(
+            """
             CREATE TABLE IF NOT EXISTS oauth_sessions (
                 did TEXT PRIMARY KEY,
                 handle TEXT NOT NULL,
@@ -327,6 +339,36 @@ def update_oauth_session_pds_nonce(conn, did, dpop_pds_nonce):
 def delete_oauth_session(conn, did):
     conn.execute("DELETE FROM oauth_sessions WHERE did = %s", (did,))
     conn.commit()
+
+
+def upsert_profile(conn, did, handle, display_name, description, avatar_url):
+    conn.execute(
+        """
+        INSERT INTO profiles (did, handle, display_name, description, avatar_url, updated_at)
+        VALUES (%s, %s, %s, %s, %s, NOW())
+        ON CONFLICT (did) DO UPDATE SET
+            handle = EXCLUDED.handle,
+            display_name = EXCLUDED.display_name,
+            description = EXCLUDED.description,
+            avatar_url = EXCLUDED.avatar_url,
+            updated_at = NOW()
+    """,
+        (did, handle, display_name, description, avatar_url),
+    )
+    conn.commit()
+
+
+def get_profile(conn, did):
+    return conn.execute(
+        "SELECT * FROM profiles WHERE did = %s", (did,)
+    ).fetchone()
+
+
+def has_profile(conn, did):
+    row = conn.execute(
+        "SELECT 1 FROM profiles WHERE did = %s", (did,)
+    ).fetchone()
+    return row is not None
 
 
 def get_activity(conn, did, rkey):

--- a/appview/app/identity.py
+++ b/appview/app/identity.py
@@ -148,3 +148,47 @@ def resolve_identity(client: httpx.Client, identifier: str) -> tuple[str, str, s
         return did, handle, pds_url
 
     raise ValueError(f"Identifier is not a valid handle or DID: {identifier}")
+
+
+def fetch_profile(client: httpx.Client, did: str, pds_url: str) -> dict | None:
+    """Fetch a user's profile from their PDS.
+
+    Makes an unauthenticated getRecord call for app.bsky.actor.profile.
+    Returns a dict with display_name, description, and avatar_url, or None
+    if the profile record doesn't exist.
+    """
+    try:
+        resp = client.get(
+            f"{pds_url}/xrpc/com.atproto.repo.getRecord",
+            params={
+                "repo": did,
+                "collection": "app.bsky.actor.profile",
+                "rkey": "self",
+            },
+            timeout=SAFE_HTTP_TIMEOUT,
+        )
+        if resp.status_code != 200:
+            log.debug("No profile record for %s: HTTP %s", did, resp.status_code)
+            return None
+    except httpx.HTTPError as e:
+        log.debug("Failed to fetch profile for %s: %s", did, e)
+        return None
+
+    value = resp.json().get("value", {})
+
+    avatar_url = None
+    avatar = value.get("avatar")
+    if avatar and isinstance(avatar, dict):
+        ref = avatar.get("ref", {})
+        cid = ref.get("$link")
+        if cid:
+            avatar_url = (
+                f"{pds_url}/xrpc/com.atproto.sync.getBlob"
+                f"?did={did}&cid={cid}"
+            )
+
+    return {
+        "display_name": value.get("displayName"),
+        "description": value.get("description"),
+        "avatar_url": avatar_url,
+    }

--- a/appview/app/main.py
+++ b/appview/app/main.py
@@ -29,9 +29,17 @@ from app.db import (
     get_activity as _get,
 )
 from app.db import (
+    get_profile,
     list_activities as _list,
+    upsert_profile,
 )
-from app.identity import is_valid_did, is_valid_handle, resolve_handle, resolve_identity
+from app.identity import (
+    fetch_profile,
+    is_valid_did,
+    is_valid_handle,
+    resolve_handle,
+    resolve_identity,
+)
 from app.parse import parse_file
 from app.tid import generate_tid
 from app.oauth import (
@@ -183,7 +191,16 @@ def resolve_handle_endpoint(handle: str):
             did, resolved_handle, pds_url = resolve_identity(client, handle)
         except ValueError as e:
             return JSONResponse(status_code=400, content={"error": str(e)})
-    return {"did": did, "handle": resolved_handle}
+
+        profile = fetch_profile(client, did, pds_url)
+
+    result = {"did": did, "handle": resolved_handle}
+    if profile:
+        result["displayName"] = profile["display_name"]
+        result["description"] = profile["description"]
+        result["avatarUrl"] = profile["avatar_url"]
+
+    return result
 
 
 # --- File parsing endpoints ---
@@ -502,11 +519,23 @@ def oauth_callback(request: Request):
                         status_code=400, content={"error": "Authorization server mismatch"}
                     )
 
+            profile = fetch_profile(client, did, pds_url)
+
         save_oauth_session(
             conn, did, handle, pds_url, authserver_iss,
             tokens["access_token"], tokens["refresh_token"],
             dpop_authserver_nonce, auth_req["dpop_private_jwk"],
         )
+
+        if profile:
+            upsert_profile(
+                conn, did, handle,
+                profile["display_name"],
+                profile["description"],
+                profile["avatar_url"],
+            )
+        else:
+            upsert_profile(conn, did, handle, None, None, None)
     finally:
         conn.close()
 
@@ -568,4 +597,19 @@ def oauth_logout(request: Request, session: dict = Depends(require_auth)):
 
 @app.get("/oauth/me")
 def oauth_me(session: dict = Depends(require_auth)):
-    return {"did": session["did"], "handle": session["handle"]}
+    did = session["did"]
+    handle = session["handle"]
+
+    conn = get_connection()
+    try:
+        profile = get_profile(conn, did)
+    finally:
+        conn.close()
+
+    result = {"did": did, "handle": handle}
+    if profile:
+        result["displayName"] = profile["display_name"]
+        result["description"] = profile["description"]
+        result["avatarUrl"] = profile["avatar_url"]
+
+    return result

--- a/appview/app/subscriber.py
+++ b/appview/app/subscriber.py
@@ -8,24 +8,73 @@ from app.db import (
     delete_activity,
     get_connection,
     get_cursor,
+    get_oauth_session,
+    has_profile,
     init_db,
     set_cursor,
     upsert_activity,
+    upsert_profile,
 )
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 log = logging.getLogger(__name__)
 
 JETSTREAM_URL = "wss://jetstream2.us-east.bsky.network/subscribe"
-COLLECTION = "app.thedistance.activity"
+COLLECTIONS = [
+    "app.thedistance.activity",
+    "app.thedistance.follow",
+    "app.thedistance.like",
+    "app.bsky.actor.profile",
+]
 CURSOR_PERSIST_INTERVAL = 50  # persist cursor every N events
 
 
 def build_url(cursor=None):
-    url = f"{JETSTREAM_URL}?wantedCollections={COLLECTION}"
+    params = "&".join(f"wantedCollections={c}" for c in COLLECTIONS)
+    url = f"{JETSTREAM_URL}?{params}"
     if cursor:
         url += f"&cursor={cursor}"
     return url
+
+
+def handle_profile_event(conn, did, op, commit):
+    if not has_profile(conn, did):
+        return
+
+    session = get_oauth_session(conn, did)
+    if not session:
+        return
+
+    handle = session["handle"]
+
+    if op == "delete":
+        upsert_profile(conn, did, handle, None, None, None)
+        log.info("Cleared profile for %s", did)
+        return
+
+    record = commit.get("record")
+    if not record:
+        return
+
+    pds_url = session["pds_url"]
+    avatar_url = None
+    avatar = record.get("avatar")
+    if avatar and isinstance(avatar, dict):
+        ref = avatar.get("ref", {})
+        cid = ref.get("$link")
+        if cid:
+            avatar_url = (
+                f"{pds_url}/xrpc/com.atproto.sync.getBlob"
+                f"?did={did}&cid={cid}"
+            )
+
+    upsert_profile(
+        conn, did, handle,
+        record.get("displayName"),
+        record.get("description"),
+        avatar_url,
+    )
+    log.info("Updated profile for %s", did)
 
 
 async def subscribe():
@@ -51,20 +100,26 @@ async def subscribe():
 
                         commit = event.get("commit", {})
                         op = commit.get("operation")
+                        collection = commit.get("collection")
                         did = event.get("did")
                         rkey = commit.get("rkey")
 
                         if not did or not rkey:
                             continue
 
-                        if op in ("create", "update"):
-                            record = commit.get("record")
-                            if record:
-                                upsert_activity(conn, did, rkey, record)
-                                log.info("Indexed %s %s/%s", op, did, rkey)
-                        elif op == "delete":
-                            delete_activity(conn, did, rkey)
-                            log.info("Deleted %s/%s", did, rkey)
+                        if collection == "app.thedistance.activity":
+                            if op in ("create", "update"):
+                                record = commit.get("record")
+                                if record:
+                                    upsert_activity(conn, did, rkey, record)
+                                    log.info("Indexed %s %s/%s", op, did, rkey)
+                            elif op == "delete":
+                                delete_activity(conn, did, rkey)
+                                log.info("Deleted %s/%s", did, rkey)
+
+                        elif collection == "app.bsky.actor.profile":
+                            handle_profile_event(conn, did, op, commit)
+
                     except Exception:
                         log.exception("Failed to process event: %s", raw[:200])
 

--- a/web/src/_components/activity-list.webc
+++ b/web/src/_components/activity-list.webc
@@ -5,14 +5,7 @@
 
 <script webc:bucket="components">
   class ActivityList extends HTMLElement {
-    connectedCallback() {
-      if (this.loading) {
-        this.insertAdjacentHTML(
-          "beforeend",
-          `<p class="loading-indicator">Looking for <s>love</s>activities in all the wrong places…</p>`
-        );
-      }
-    }
+    connectedCallback() {}
 
     get editable() {
       return this.hasAttribute("editable");
@@ -35,7 +28,6 @@
         this.setAttribute("loading", "");
       } else {
         this.removeAttribute("loading");
-        this.querySelector(".loading-indicator")?.remove();
       }
     }
 
@@ -44,11 +36,13 @@
       this.querySelector(".preview").remove();
 
       if (data.length === 0) {
-        this.insertAdjacentHTML("beforeend", "<p>No Activities yet</p>");
+        this.insertAdjacentHTML(
+          "beforeend",
+          "<p class='zero'>No Activities yet</p>"
+        );
         return;
       }
 
-      // https://bsky.app/profile/jamellebouie.net/post/3mjkzfkmvvs2g
       const activitiesHTML = `
       <ul>
         ${data
@@ -231,6 +225,12 @@ async function handleDelete(e) {
         width: 100%;
       }
     }
+  }
+
+  .zero {
+    font-weight: 500;
+    padding: 3rem 0.5rem;
+    text-align: center;
   }
 
   ul {

--- a/web/src/_components/auth-form.webc
+++ b/web/src/_components/auth-form.webc
@@ -193,6 +193,7 @@
       const data = await res.json();
       window.location.href = data.redirect_url;
     } catch (err) {
+      // FIXME: Handle fetch failure correctly
       alert("Login failed: " + err.message);
     } finally {
       btn.disabled = false;

--- a/web/src/_components/page-header.webc
+++ b/web/src/_components/page-header.webc
@@ -19,9 +19,12 @@
 </header>
 
 <script webc:bucket="components">
-  async function logout() {
+  async function logout(e) {
+    e.preventDefault();
     localStorage.removeItem("auth:user");
-    window.location.href = "/";
+
+    const nav = document.getElementById("page-header-nav");
+    nav.innerHTML = `<a :href="/" class="btn" id="page-header-auth-btn">Log in / Join</a>`;
 
     try {
       await fetch(`${API_BASE}/oauth/logout`, {
@@ -31,6 +34,8 @@
     } catch {
       // Continue with local cleanup even if server call fails
     }
+
+    window.location.href = "/";
   }
 
   function getAuthedUI(handle) {

--- a/web/src/_components/page-header.webc
+++ b/web/src/_components/page-header.webc
@@ -12,9 +12,7 @@
   </h1>
 
   <nav id="page-header-nav">
-    <a :href="loginHref" class="btn hidden" id="page-header-auth-btn"
-      >Log in / Join</a
-    >
+    <a :href="loginHref" class="btn" id="page-header-auth-btn">Log in / Join</a>
   </nav>
 
   <scheme-chooser></scheme-chooser>
@@ -22,6 +20,9 @@
 
 <script webc:bucket="components">
   async function logout() {
+    localStorage.removeItem("auth:user");
+    window.location.href = "/";
+
     try {
       await fetch(`${API_BASE}/oauth/logout`, {
         ...FETCH_OPTS,
@@ -30,12 +31,10 @@
     } catch {
       // Continue with local cleanup even if server call fails
     }
-    window.location.href = "/";
   }
 
   function getAuthedUI(handle) {
     return `
-      <span class="divider">|</span> 
       <a href="/profile/${handle}"><b class="at">@</b>${handle}</a>
       <button id="logout-btn" type="button">Log out</button> 
       <a href="/upload" class="btn">
@@ -44,21 +43,18 @@
       </a>`;
   }
 
-  document.addEventListener("afterAuthCheck", (e) => {
-    const { user } = e.detail;
-    const authBtn = document.getElementById("page-header-auth-btn");
-
-    if (!user) {
-      authBtn.classList.remove("hidden");
-      return;
-    }
-
+  function onUserAvailable(user) {
     const nav = document.getElementById("page-header-nav");
-    authBtn.remove();
-    nav.insertAdjacentHTML("beforeend", getAuthedUI(user.handle));
+    nav.innerHTML = getAuthedUI(user.handle);
 
     const logoutBtn = document.getElementById("logout-btn");
     logoutBtn.addEventListener("click", logout);
+  }
+
+  document.addEventListener("afterAuthCheck", (e) => {
+    const { user } = e.detail;
+    if (!user) return;
+    onUserAvailable(user);
   });
 </script>
 

--- a/web/src/app.js
+++ b/web/src/app.js
@@ -16,13 +16,34 @@ getAuthedUser().then((user) => {
  * @returns {Promise<{did: string, handle: string}|null>} The authenticated user, or null if not authenticated.
  */
 async function getAuthedUser() {
+  /*
+    Look for a cached user object in localstorage, if found, use it instead of
+    making a trip to the server. If any other auth-required request fails with
+    a 401, we clear the cache/logout.
+  */
+  const cachedUser = localStorage.getItem("auth:user");
+  try {
+    if (cachedUser) {
+      const user = JSON.parse(cachedUser);
+      // Wait until the next loop to make sure components are in the DOM.
+      await sleep(0);
+      return user;
+    }
+  } catch (e) {
+    console.warn(e);
+  }
+
   try {
     const res = await fetch(`${API_BASE}/oauth/me`, FETCH_OPTS);
     if (res.ok) {
       const user = await res.json();
+      // Cache the user object so we don't need to fetch it on every page.
+      localStorage.setItem("auth:user", JSON.stringify(user));
       return user;
     }
   } catch (e) {
+    // FIXME: Handle fetch failure
+    console.log(e.message);
     return null;
   }
 
@@ -33,7 +54,7 @@ async function getAuthedUser() {
  * @param {string} handle
  * @returns {Promise<{did: string, handle: string}|null>} The resolved user, or null if not found.
  */
-async function lookupHandle(handle) {
+async function getUserByHandle(handle) {
   try {
     const res = await fetch(
       `${API_BASE}/api/resolve/${encodeURIComponent(handle)}`,
@@ -221,4 +242,8 @@ function formatDate(iso) {
     month: "short",
     day: "numeric",
   });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/web/src/profile/activity/index.webc
+++ b/web/src/profile/activity/index.webc
@@ -24,7 +24,8 @@ title: Activity - The Distance
   );
   const activityIdentifier = activityPathMatch ? activityPathMatch[1] : null;
   const activityRkey = activityPathMatch ? activityPathMatch[2] : null;
-  const activityIdentifierIsDid = activityIdentifier && activityIdentifier.startsWith("did:");
+  const activityIdentifierIsDid =
+    activityIdentifier && activityIdentifier.startsWith("did:");
 
   async function renderActivity(did, handle) {
     const { data, error } = await getActivity(did, activityRkey);
@@ -44,14 +45,15 @@ title: Activity - The Distance
     const { user } = e.detail;
 
     if (activityIdentifierIsDid) {
-      const handle = user && user.did === activityIdentifier ? user.handle : null;
+      const handle =
+        user && user.did === activityIdentifier ? user.handle : null;
       renderActivity(activityIdentifier, handle);
     } else {
       // Identifier is a handle, resolve to DID
       if (user && user.handle === activityIdentifier) {
         renderActivity(user.did, user.handle);
       } else {
-        lookupHandle(activityIdentifier).then((foundUser) => {
+        getUserByHandle(activityIdentifier).then((foundUser) => {
           if (!foundUser) {
             const list = document.getElementById("activity-detail");
             list.loading = false;

--- a/web/src/profile/index.webc
+++ b/web/src/profile/index.webc
@@ -5,60 +5,113 @@ title: Profile - The Distance
 
 <div class="g-max-centered">
   <div class="contents">
-    <h2 id="profile-handle">&nbsp;</h2>
+    <header class="profile-header">
+      <div class="profile-avatar"></div>
+      <div class="profile-contents">
+        <p class="profile-dname">&nbsp;</p>
+        <p class="profile-handle">&nbsp;</p>
+        <div class="profile-desc">&nbsp;</div>
+      </div>
+    </header>
     <activity-list id="profile-activities" loading></activity-list>
   </div>
 </div>
 
 <style webc:scoped>
   .contents {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
     margin: 0 auto;
     max-width: var(--grid-max-5);
     padding-bottom: 2rem;
+    padding-top: 2rem;
+  }
+
+  .profile-header {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    letter-spacing: -1%;
+    line-height: 1.25;
+  }
+
+  .profile-contents {
+    flex: 1;
+  }
+
+  .profile-dname {
+    font-size: var(--font-size-2);
+    font-weight: 700;
+  }
+
+  .profile-desc {
+    padding-top: 1.25rem;
+  }
+
+  .profile-avatar {
+    --size: 100px;
+    background: color-mix(in srgb, var(--color-foreground) 10%, transparent);
+    border-radius: 20px;
+    box-shadow: 0 0 1px
+      color-mix(in srgb, var(--color-foreground) 20%, transparent);
+    height: var(--size);
+    overflow: hidden;
+    width: var(--size);
+
+    img {
+      display: block;
+      height: 100%;
+      object-fit: cover;
+      object-position: center;
+      width: 100%;
+    }
   }
 </style>
 
 <script webc:bucket="components">
   const [_, rawHandle] = window.location.pathname.split("/profile/");
   const requestedHandle = rawHandle.replaceAll("/", "");
-  const title = document.getElementById("profile-handle");
+  const handle = document.querySelector(".profile-handle");
+  handle.textContent = `@${requestedHandle}`;
+  document.title = `@${requestedHandle} is Going The Distance`;
 
   async function renderProfile({ user }) {
-    title.textContent = `@${user.handle}`;
-    document.title = `@${user.handle} is Going The Distance`;
-
     const { data } = await getActivities(user.did);
+    const dname = document.querySelector(".profile-dname");
+    dname.textContent = user.displayName;
+
+    const desc = document.querySelector(".profile-desc");
+    if (user.description) {
+      desc.innerHTML = user.description
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/\n/g, "<br>");
+    }
+
+    if (user.avatarUrl) {
+      const img = new Image();
+      img.onload = () => {
+        img.alt = `${user.displayName || user.handle}`;
+        document.querySelector(".profile-avatar").appendChild(img);
+      };
+      img.src = user.avatarUrl;
+    }
+
     const list = document.getElementById("profile-activities");
     list.handle = user.handle;
     list.activities = data;
-
-    // FIXME: Do something with this or remove
-    // if (user) {
-    //   const isOwner = user.did === did;
-    //   list.editable = isOwner;
-    // }
   }
 
-  document.addEventListener("afterAuthCheck", (e) => {
-    const { user } = e.detail;
-
-    if (user) {
-      const requestedIsCurrent = user.handle === requestedHandle;
-
-      if (requestedIsCurrent) {
-        renderProfile({ user });
-        return;
-      }
+  getUserByHandle(requestedHandle).then((foundUser) => {
+    if (!foundUser) {
+      document.getElementById("profile-activities").remove();
+      title.textContent = `Couldn’t find @${requestedHandle}`;
+      document.title = "The Distance";
+      return;
     }
 
-    lookupHandle(requestedHandle).then((foundUser) => {
-      if (!foundUser) {
-        title.textContent = `Couldn’t find an @${requestedHandle}`;
-        document.title = "The Distance";
-        return;
-      }
-
-      renderProfile({ user: foundUser });
-    });
+    renderProfile({ user: foundUser });
   });
 </script>


### PR DESCRIPTION
**Changes**

- Fetches user profile data (display name, description, avatar) from the user's PDS via `com.atproto.repo.getRecord` for `app.bsky.actor.profile`. Works across AT Protocol providers (Bluesky, Blacksky, etc.)
- New `profiles` database table for caching profile data for logged-in users
- `/oauth/callback` now fetches and stores the user's profile on login
- `/oauth/me` returns profile fields (`displayName`, `description`, `avatarUrl`) alongside `did` and `handle`
- `/api/resolve/{handle}` now fetches and returns profile data for any AT Protocol user (not cached, always fresh from PDS)
- Jetstream subscriber expanded to listen for `app.thedistance.follow`, `app.thedistance.like`, and `app.bsky.actor.profile` collections. Profile updates are processed for known users; follow and like events are received but not yet processed
- `getAuthedUser` now uses a localStorage cache to avoid hitting `/oauth/me` on every page load, with a deferred dispatch to avoid timing issues with component listeners
- Profile page redesigned with avatar (skeleton loading state, image appended only after load), display name, handle, and description with newline support
- Profile page fetches user data immediately via `getUserByHandle` instead of waiting for `afterAuthCheck`
- Renamed `lookupHandle` to `getUserByHandle`
- Header nav cleanup: simplified auth UI rendering, logout now clears localStorage cache before redirect
