### PR TITLE
Fixes Minor Style Issues

### DIFF
--- a/web/src/_components/activity-list.webc
+++ b/web/src/_components/activity-list.webc
@@ -368,7 +368,8 @@ async function handleDelete(e) {
       text-overflow: ellipsis;
       white-space: nowrap;
 
-      &:where(:hover, :focus-visible) {
+      &:hover,
+      &:focus-visible {
         text-decoration: underline;
       }
     }

--- a/web/src/_components/activity-upload-form.webc
+++ b/web/src/_components/activity-upload-form.webc
@@ -59,7 +59,7 @@
     position: relative;
     text-align: center;
 
-    &:not(&:has(input[disabled])):where(:hover, :focus-visible),
+    &:not(&:has(input[disabled])):where(:hover, :focus-within),
     &.drag-over {
       background-color: color-mix(
         in srgb,

--- a/web/src/_components/page-footer.webc
+++ b/web/src/_components/page-footer.webc
@@ -111,7 +111,8 @@
         color: currentColor;
         text-decoration: none;
 
-        &:where(:hover, :focus-visible) {
+        &:hover,
+        &:focus-visible {
           text-decoration: underline;
         }
       }
@@ -140,7 +141,8 @@
           width: var(--size);
         }
 
-        &:where(:hover, :focus-visible) {
+        &:hover,
+        &:focus-visible {
           color: var(--color-accent-foreground);
 
           svg {

--- a/web/src/_components/page-header.webc
+++ b/web/src/_components/page-header.webc
@@ -135,7 +135,8 @@
       padding: 0.2rem 0.6rem;
       text-decoration: none;
 
-      &:where(:hover, :focus-visible) {
+      &:hover,
+      &:focus-visible {
         border-color: light-dark(
           hsl(var(--color-foreground-hsl-light) / 25%),
           hsl(var(--color-foreground-hsl-dark) / 25%)

--- a/web/src/_components/scheme-chooser.webc
+++ b/web/src/_components/scheme-chooser.webc
@@ -43,10 +43,13 @@
 </button>
 
 <script webc:bucket="components">
-  const STORAGE_KEY = "settings:colorScheme";
+  /*
+    NOTE: We do an initial check/set of the scheme in layout.webc to avoid
+    an initial flash if the user has chosen dark scheme.
+  */
 
   function getScheme() {
-    return localStorage.getItem(STORAGE_KEY) || "light";
+    return localStorage.getItem(COLOR_SCHEME_STORAGE_KEY) || "light";
   }
 
   function applyScheme(scheme) {
@@ -64,7 +67,7 @@
   function toggleScheme(e) {
     e.preventDefault();
     const next = getScheme() === "light" ? "dark" : "light";
-    localStorage.setItem(STORAGE_KEY, next);
+    localStorage.setItem(COLOR_SCHEME_STORAGE_KEY, next);
     applyScheme(next);
   }
 

--- a/web/src/_components/scheme-chooser.webc
+++ b/web/src/_components/scheme-chooser.webc
@@ -89,7 +89,8 @@
     padding: 0.35rem;
     text-decoration: none;
 
-    &:where(:hover, :focus-visible) {
+    &:hover,
+    &:focus-visible {
       border-color: light-dark(
         hsl(var(--color-foreground-hsl-light) / 25%),
         hsl(var(--color-foreground-hsl-dark) / 25%)

--- a/web/src/_includes/layout.webc
+++ b/web/src/_includes/layout.webc
@@ -7,6 +7,13 @@
 
     <script @raw="`const API_BASE = '${site.apiBase}';`" webc:keep>
       const FETCH_OPTS = { credentials: "include" };
+
+      /*
+        We set any selected color scheme before anything else to avoid any flash.
+      */
+      const COLOR_SCHEME_STORAGE_KEY = "settings:colorScheme";
+      document.documentElement.style.colorScheme =
+        localStorage.getItem(COLOR_SCHEME_STORAGE_KEY) || "light";
     </script>
 
     <link rel="stylesheet" href="/vendor/maplibre-gl.css" webc:keep />


### PR DESCRIPTION
**Changes**

- Checks/Sets color scheme immediately to avoid flash if user has dark scheme set
- Removes unneeded `:where` from a number of selectors
- Uses `:focus-within` instead of `:focus-visible` (because that was the wrong thing)